### PR TITLE
feat: optionally save AAP admin credentials as k8s secret

### DIFF
--- a/roles/ocp4_workload_ansible_automation_platform/defaults/main.yml
+++ b/roles/ocp4_workload_ansible_automation_platform/defaults/main.yml
@@ -22,6 +22,10 @@ ocp4_workload_ansible_automation_platform_catalog_snapshot_image_tag: v4.19_2025
 # ---------------------------------------------------------------
 ocp4_workload_ansible_automation_platform_admin_password: ""
 ocp4_workload_ansible_automation_platform_admin_password_length: 16
+
+# Save admin credentials in a secret in the AAP namespace
+ocp4_workload_ansible_automation_platform_save_admin_credentials: false
+ocp4_workload_ansible_automation_platform_admin_credentials_secret: aap-admin-credentials
 ocp4_workload_ansible_automation_platform_disable_controller: false
 ocp4_workload_ansible_automation_platform_disable_eda: false
 ocp4_workload_ansible_automation_platform_disable_hub: true

--- a/roles/ocp4_workload_ansible_automation_platform/tasks/workload.yml
+++ b/roles/ocp4_workload_ansible_automation_platform/tasks/workload.yml
@@ -116,6 +116,23 @@
     state: present
     template: eda_cluster_rolebinding.yaml.j2
 
+- name: Create AAP admin credentials secret
+  when: ocp4_workload_ansible_automation_platform_save_admin_credentials | bool
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: "{{ ocp4_workload_ansible_automation_platform_admin_credentials_secret }}"
+        namespace: "{{ ocp4_workload_ansible_automation_platform_project }}"
+      type: Opaque
+      stringData:
+        username: admin
+        password: "{{ _ocp4_workload_ansible_automation_platform_admin_password }}"
+        url: "{{ automation_controller_url }}"
+  no_log: true
+
 - name: Print & save AAP access information
   agnosticd.core.agnosticd_user_info:
     msg: >-


### PR DESCRIPTION
## Summary
- Adds `ocp4_workload_ansible_automation_platform_save_admin_credentials` boolean (default: false)
- When true, creates an Opaque secret `aap-admin-credentials` in the AAP namespace containing admin username, password, and controller URL
- Follows the same pattern as `ocp4_workload_quay_operator` (PR #110)

## Motivation
Tenant workloads need AAP controller credentials but component propagation doesn't flow to sandbox API tenants. Storing credentials in a k8s secret allows tenants to read them directly using the cluster admin token.

## Test plan
- [ ] Deploy AAP with `ocp4_workload_ansible_automation_platform_save_admin_credentials: true`
- [ ] Verify secret `aap-admin-credentials` exists in the `aap` namespace
- [ ] Verify secret contains `username`, `password`, and `url` keys

Generated with [Claude Code](https://claude.com/claude-code)