### PR TITLE
Feature devspaces oauth grant method treddy

### DIFF
--- a/roles/ocp4_workload_devspaces/defaults/main.yml
+++ b/roles/ocp4_workload_devspaces/defaults/main.yml
@@ -63,3 +63,6 @@ ocp4_workload_devspaces_oauth_access_token_inactivity_timeout: ""
 # Example recommended values to prevent double-auth:
 # ocp4_workload_devspaces_oauth_access_token_max_age_seconds: 86400
 # ocp4_workload_devspaces_oauth_access_token_inactivity_timeout: 3600
+
+# Set to "auto" to skip OAuth consent screen, preventing iframe auth issues
+ocp4_workload_devspaces_oauth_grant_method: ""

--- a/roles/ocp4_workload_devspaces/tasks/workload.yml
+++ b/roles/ocp4_workload_devspaces/tasks/workload.yml
@@ -78,9 +78,6 @@
       loop_var: n
       label: "{{ ocp4_workload_devspaces_user_base }}{{ n }}"
 
-- name: Save user information
-  ansible.builtin.include_tasks: save_user_information.yml
-
 - name: Configure OAuth grant method
   when:
   - ocp4_workload_devspaces_oauth_grant_method is defined
@@ -95,3 +92,6 @@
   retries: 30
   delay: 10
   until: r_oauth_grant_method is successful
+
+- name: Save user information
+  ansible.builtin.include_tasks: save_user_information.yml

--- a/roles/ocp4_workload_devspaces/tasks/workload.yml
+++ b/roles/ocp4_workload_devspaces/tasks/workload.yml
@@ -80,3 +80,18 @@
 
 - name: Save user information
   ansible.builtin.include_tasks: save_user_information.yml
+
+- name: Configure OAuth grant method
+  when:
+  - ocp4_workload_devspaces_oauth_grant_method is defined
+  - ocp4_workload_devspaces_oauth_grant_method | length > 0
+  kubernetes.core.k8s:
+    api_version: oauth.openshift.io/v1
+    kind: OAuthClient
+    name: openshift-devspaces-client
+    definition:
+      grantMethod: "{{ ocp4_workload_devspaces_oauth_grant_method }}"
+  register: r_oauth_grant_method
+  retries: 30
+  delay: 10
+  until: r_oauth_grant_method is successful


### PR DESCRIPTION
Allow developers to set the default auth method.  Currently set to prompt -> Does not work well in iframe.  Disabling for embedded devspaces.