### PR TITLE
Add pipelines console plugin enablement

### DIFF
--- a/roles/ocp4_workload_pipelines/defaults/main.yml
+++ b/roles/ocp4_workload_pipelines/defaults/main.yml
@@ -21,6 +21,9 @@ ocp4_workload_pipelines_starting_csv: ""
 # part of a openshift-cluster deployment. When just deploying the workload no bastions are available.
 ocp4_workload_pipelines_install_cli_tools: false
 
+# Enable the pipelines console plugin in the OpenShift web console
+ocp4_workload_pipelines_enable_console_plugin: true
+
 # --------------------------------
 # Operator Catalog Snapshot Settings
 # --------------------------------

--- a/roles/ocp4_workload_pipelines/tasks/workload.yml
+++ b/roles/ocp4_workload_pipelines/tasks/workload.yml
@@ -33,6 +33,17 @@
   - r_pipeline_controller_deployment.resources[0].status.readyReplicas is defined
   - r_pipeline_controller_deployment.resources[0].status.readyReplicas | int == r_pipeline_controller_deployment.resources[0].spec.replicas | int
 
+- name: Enable pipelines console plugin
+  when: ocp4_workload_pipelines_enable_console_plugin | bool
+  kubernetes.core.k8s_json_patch:
+    api_version: operator.openshift.io/v1
+    kind: Console
+    name: cluster
+    patch:
+    - op: add
+      path: /spec/plugins/-
+      value: pipelines-console-plugin
+
 - name: Install tkn cli tools
   when: ocp4_workload_pipelines_install_cli_tools | default(false)
   block:


### PR DESCRIPTION
Latest version of OpenShift Pipelines doesn't bring the pipelines plugin by default, so the Pipelines menu option in the console, doesn't show up.