### PR TITLE
gitops_bootstrap: Add opt-in ignoreDifferences for child Application CRD tracking drift

### DIFF
--- a/roles/ocp4_workload_gitops_bootstrap/defaults/main.yml
+++ b/roles/ocp4_workload_gitops_bootstrap/defaults/main.yml
@@ -37,3 +37,15 @@ ocp4_workload_gitops_bootstrap_application_health_retries: 90
 ocp4_workload_gitops_bootstrap_application_health_required: true
 
 ocp4_workload_gitops_bootstrap_application_sync_required: true # false is great for development
+
+# When the bootstrap manages child Application CRDs that include complex or
+# long-running workloads (e.g. an ArgoCD instance deployed by an operator),
+# ArgoCD adds tracking annotations and a transient .operation field to those
+# CRDs after creation. These fields are not present in the Helm template, so
+# the bootstrap reports OutOfSync during the window when child apps are
+# actively syncing — which can cause provisioning wait tasks to time out.
+#
+# Set to true to add ignoreDifferences rules for /metadata/annotations and
+# /operation on child Application CRDs. Has no effect on other resource types.
+# Default: false — existing labs are unaffected unless they opt in.
+ocp4_workload_gitops_bootstrap_application_ignore_tracking: false

--- a/roles/ocp4_workload_gitops_bootstrap/templates/application.yaml.j2
+++ b/roles/ocp4_workload_gitops_bootstrap/templates/application.yaml.j2
@@ -50,3 +50,13 @@ spec:
             operator: Exists
       jsonPointers:
         - /data
+    # ArgoCD adds a tracking annotation (argocd.argoproj.io/tracking-id) and a
+    # transient .operation field to every resource it manages, including the child
+    # Application CRDs this bootstrap creates. Without this entry the bootstrap
+    # reports OutOfSync whenever a child Application is actively syncing or has
+    # been annotated — causing provisioning wait tasks to time out.
+    - group: argoproj.io
+      kind: Application
+      jsonPointers:
+        - /metadata/annotations
+        - /operation

--- a/roles/ocp4_workload_gitops_bootstrap/templates/application.yaml.j2
+++ b/roles/ocp4_workload_gitops_bootstrap/templates/application.yaml.j2
@@ -50,13 +50,16 @@ spec:
             operator: Exists
       jsonPointers:
         - /data
+{% if ocp4_workload_gitops_bootstrap_application_ignore_tracking | bool %}
     # ArgoCD adds a tracking annotation (argocd.argoproj.io/tracking-id) and a
     # transient .operation field to every resource it manages, including the child
     # Application CRDs this bootstrap creates. Without this entry the bootstrap
     # reports OutOfSync whenever a child Application is actively syncing or has
     # been annotated — causing provisioning wait tasks to time out.
+    # Enabled via: ocp4_workload_gitops_bootstrap_application_ignore_tracking: true
     - group: argoproj.io
       kind: Application
       jsonPointers:
         - /metadata/annotations
         - /operation
+{% endif %}


### PR DESCRIPTION
## Summary

Adds an opt-in variable (`ocp4_workload_gitops_bootstrap_application_ignore_tracking`, default `false`) that prevents the bootstrap Application from reporting transient OutOfSync status when child Applications deploy slow-starting, operator-backed workloads.

## Problem

When the bootstrap manages a child Application that deploys a complex workload such as an ArgoCD instance (via the OpenShift GitOps operator), the provisioning task **"Wait until bootstrap ArgoCD application is healthy and synced"** consistently times out — even though all child Applications are `Synced + Healthy`.

**Root causes identified (two, both real):**

1. **ArgoCD tracking annotation drift** — ArgoCD adds a `argocd.argoproj.io/tracking-id` annotation to every resource it manages, including child Application CRDs the bootstrap creates. This field is not in the Helm template, so the bootstrap reports OutOfSync during active sync windows.

2. **`syncPolicy.automated` normalization** *(separate fix in the consuming repo)* — ArgoCD normalizes `selfHeal: false` and `prune: false` out of Application CRD specs (they are the defaults). Templates that render these explicitly will always differ from what ArgoCD stores, causing persistent OutOfSync regardless of the annotation fix. **The consuming repo must use `automated: {}` instead of explicit false defaults.**

This PR addresses cause #1 via the `ignoreDifferences` opt-in. Cause #2 must be fixed in the chart templates of the consuming repo.

## Changes

### `defaults/main.yml`

Adds `ocp4_workload_gitops_bootstrap_application_ignore_tracking: false` with a full explanatory comment. Default is `false` — **all existing labs are unaffected unless they explicitly opt in**.

### `templates/application.yaml.j2`

Wraps a new `ignoreDifferences` block in a Jinja conditional. When the variable is `true`, adds two entries for `argoproj.io/Application` resources:
- `/metadata/annotations` — the tracking-id annotation ArgoCD injects after creation
- `/operation` — the transient sync operation field written during active syncs

**This does not ignore differences in the Application `spec` or `status`** — real configuration drift in child Applications remains visible.

## Usage

```yaml
ocp4_workload_gitops_bootstrap_application_ignore_tracking: true
```