### PR TITLE
[ocp4_workload_gitea_operator] Add packages storage path variable

### DIFF
--- a/roles/ocp4_workload_gitea_operator/defaults/main.yml
+++ b/roles/ocp4_workload_gitea_operator/defaults/main.yml
@@ -104,6 +104,13 @@ ocp4_workload_gitea_operator_mailer_helo_hostname: ''
 ocp4_workload_gitea_operator_webhook_allowed_hosts_list: 'external,private'
 ocp4_workload_gitea_operator_webhook_skip_tls_verify: false
 
+# Packages storage path. When set, configures the Gitea [packages] PATH in app.ini.
+# Use a path on the persistent volume (e.g. /gitea-repositories/packages) to
+# ensure package registry contents (Helm charts, etc.) survive pod restarts.
+# Requires gitea-operator v2.2.0 or later (giteaPackagesPath CR field).
+# Leave empty to use Gitea's compiled-in default (/home/gitea/data/packages/).
+ocp4_workload_gitea_operator_packages_storage_path: ""
+
 # Create an admin user (delegated to the operator as of Operator v1.1.0)
 # Note: the admin user can NOT be named 'admin'
 ocp4_workload_gitea_operator_create_admin: false

--- a/roles/ocp4_workload_gitea_operator/templates/gitea.yaml.j2
+++ b/roles/ocp4_workload_gitea_operator/templates/gitea.yaml.j2
@@ -61,3 +61,6 @@ spec:
 
   giteaWebhookAllowedHostList: {{ocp4_workload_gitea_operator_webhook_allowed_hosts_list }}
   giteaWebhookSkipTlsVerify: {{ ocp4_workload_gitea_operator_webhook_skip_tls_verify | bool }}
+{% if ocp4_workload_gitea_operator_packages_storage_path | default("") | length > 0 %}
+  giteaPackagesPath: {{ ocp4_workload_gitea_operator_packages_storage_path }}
+{% endif %}


### PR DESCRIPTION
## Problem

Gitea stores packages (Helm charts, npm packages, etc.) at \`/home/gitea/data/packages/\` by default. This path is in the container's ephemeral overlay filesystem — it is **not** on the PVC, which is only mounted at \`/gitea-repositories\` (git repo data).

On any pod restart — from node pressure, OOM eviction, or routine maintenance — all package registry contents are silently lost. Labs that publish Helm charts to Gitea's package registry and rely on \`helm install\` from it will fail after the first pod restart without any obvious error.

## Solution

Adds \`ocp4_workload_gitea_operator_packages_storage_path\` (default: empty string). When set, it renders \`giteaPackagesPath\` into the Gitea CR spec, which causes the operator to write a \`[packages] PATH\` entry into the generated \`app.ini\`.

Setting this to \`/gitea-repositories/packages\` (on the PVC) makes the package registry persistent across pod restarts and operator reconciliation cycles.

## Changes

- \`defaults/main.yml\`: new variable \`ocp4_workload_gitea_operator_packages_storage_path: ""\` with documentation comment
- \`templates/gitea.yaml.j2\`: conditional \`giteaPackagesPath\` field in the Gitea CR spec

## Depends On

rhpds/gitea-operator#37 — the \`giteaPackagesPath\` CR field must exist in the operator before this variable has any effect. The CR field is ignored by older operator versions, so this change is safe to merge ahead of the operator release.

## Backward Compatibility

Empty by default. No Gitea CR or \`app.ini\` changes for deployments that do not set this variable.

## Example (AgnosticV catalog)

\`\`\`yaml
ocp4_workload_gitea_operator_packages_storage_path: /gitea-repositories/packages
\`\`\`