### PR TITLE
ocp4_workload_gitops_add_cluster

### DIFF
--- a/roles/ocp4_workload_gitops_add_cluster/defaults/main.yml
+++ b/roles/ocp4_workload_gitops_add_cluster/defaults/main.yml
@@ -1,0 +1,27 @@
+---
+# Directory on the bastion host to search for kubeconfig files.
+ocp4_workload_gitops_add_cluster_kubeconfig_dir: /home/cloud-user
+
+# Glob pattern used to find kubeconfig files within the directory above.
+# Only files whose names match this pattern are considered.
+ocp4_workload_gitops_add_cluster_kubeconfig_pattern: "*kubeconfig*"
+
+# ArgoCD namespace where the gitops instance is running.
+ocp4_workload_gitops_add_cluster_argocd_namespace: openshift-gitops
+
+# Whether to skip TLS verification when ArgoCD connects to discovered clusters.
+# defaults to secure because we usually have the caData from kubeconfig
+ocp4_workload_gitops_add_cluster_cluster_insecure: false
+
+# Dict of clusters to add, keyed by cluster name.
+# Each entry requires 'api_url' and 'api_token'.
+# Uses the same format as the AgnosticV 'clusters' variable.
+# Example:
+#   ocp4_workload_gitops_add_cluster_clusters:
+#     sno1:
+#       api_url: https://api.sno1.example.com:6443
+#       api_token: sha256~xxxx
+#     sno2:
+#       api_url: https://api.sno2.example.com:6443
+#       api_token: sha256~xxxx
+ocp4_workload_gitops_add_cluster_clusters: {}

--- a/roles/ocp4_workload_gitops_add_cluster/meta/main.yml
+++ b/roles/ocp4_workload_gitops_add_cluster/meta/main.yml
@@ -1,0 +1,17 @@
+---
+galaxy_info:
+  role_name: ocp4_workload_gitops_add_cluster
+  author: Red Hat
+  description: |
+    Add external clusters to the local ArgoCD instance by discovering
+    kubeconfig files on the bastion host and registering any clusters
+    not already present.
+  license: MIT
+  min_ansible_version: "2.9"
+  platforms: []
+  galaxy_tags:
+  - ocp
+  - openshift
+  - gitops
+  - argocd
+dependencies: []

--- a/roles/ocp4_workload_gitops_add_cluster/readme.adoc
+++ b/roles/ocp4_workload_gitops_add_cluster/readme.adoc
@@ -1,0 +1,102 @@
+= ocp4_workload_gitops_add_cluster - Add external clusters to ArgoCD
+
+== Role overview
+
+This workload registers external OpenShift clusters with the local ArgoCD (OpenShift GitOps) instance. It supports two methods for discovering clusters, which can be used independently or together:
+
+1. **Explicit clusters via variables** -- provide a dict of cluster API URLs and tokens (same format as the AgnosticV `clusters` variable).
+2. **Kubeconfig discovery** -- automatically find kubeconfig files on the bastion host and register the clusters they contain.
+
+Clusters that are already registered in ArgoCD are skipped. The hub cluster (where ArgoCD runs) is also excluded automatically.
+
+=== Task files
+
+* link:./tasks/workload.yml[workload.yml] -- Provision: discovers and registers clusters with ArgoCD.
+* link:./tasks/add_cluster_from_kubeconfig.yml[add_cluster_from_kubeconfig.yml] -- Processes a single kubeconfig file, extracts unique clusters, and creates ArgoCD cluster secrets.
+* link:./tasks/remove_workload.yml[remove_workload.yml] -- Removal is not implemented. Remove clusters manually from ArgoCD if needed.
+
+=== How it works
+
+. Queries existing ArgoCD cluster secrets (label `argocd.argoproj.io/secret-type=cluster`) and builds a list of already-registered server URLs. The hub cluster's `openshift_api_url` is added to this list so it is never re-registered.
+. If `ocp4_workload_gitops_add_cluster_clusters` is provided, iterates over the dict and creates an ArgoCD cluster secret for each entry not already registered. Authentication uses a bearer token (`api_token`).
+. Searches the bastion host for kubeconfig files matching the configured pattern. For each file, parses the YAML, deduplicates by server URL, extracts credentials (client certificate or token), and creates ArgoCD cluster secrets for any clusters not already registered.
+
+== Prerequisites
+
+* OpenShift GitOps (ArgoCD) must be installed on the hub cluster (e.g. via `ocp4_workload_openshift_gitops`).
+* For kubeconfig discovery: a bastion host must be accessible via the `bastions` inventory group.
+* For explicit clusters: each target cluster must have a service account with a long-lived token and `cluster-admin` privileges (e.g. created by the `openshift_cluster_admin_service_account` role in agnosticd-v2).
+
+== Variables
+
+=== Explicit cluster registration
+
+[cols="3,1,5",options="header"]
+|===
+| Variable | Default | Description
+
+| `ocp4_workload_gitops_add_cluster_clusters`
+| `{}`
+| Dict of clusters to add, keyed by cluster name. Each entry requires `api_url` and `api_token`. Uses the same format as the AgnosticV `clusters` variable.
+|===
+
+Example:
+
+[source,yaml]
+----
+ocp4_workload_gitops_add_cluster_clusters:
+  sno1:
+    api_url: https://api.sno1.example.com:6443
+    api_token: "{{ openshift_cluster_admin_token }}"
+  sno2:
+    api_url: https://api.sno2.example.com:6443
+    api_token: sha256~xxxx
+----
+
+=== Kubeconfig discovery
+
+[cols="3,1,5",options="header"]
+|===
+| Variable | Default | Description
+
+| `ocp4_workload_gitops_add_cluster_kubeconfig_dir`
+| `/home/cloud-user`
+| Directory on the bastion host to search for kubeconfig files.
+
+| `ocp4_workload_gitops_add_cluster_kubeconfig_pattern`
+| `*kubeconfig*`
+| Glob pattern for matching kubeconfig file names. The search is recursive.
+|===
+
+=== General
+
+[cols="3,1,5",options="header"]
+|===
+| Variable | Default | Description
+
+| `ocp4_workload_gitops_add_cluster_argocd_namespace`
+| `openshift-gitops`
+| Namespace where the ArgoCD instance is running.
+
+| `ocp4_workload_gitops_add_cluster_cluster_insecure`
+| `true`
+| Whether to skip TLS verification when ArgoCD connects to discovered clusters.
+|===
+
+== AgnosticV usage
+
+[source,yaml]
+----
+workloads:
+- agnosticd.core_workloads.ocp4_workload_gitops_add_cluster
+
+# Explicit clusters (token-based)
+ocp4_workload_gitops_add_cluster_clusters:
+  sno1:
+    api_url: "{{ sno1_api_url }}"
+    api_token: "{{ sno1_cluster_admin_token }}"
+
+# Kubeconfig discovery (runs in addition to explicit clusters)
+ocp4_workload_gitops_add_cluster_kubeconfig_dir: /home/cloud-user
+ocp4_workload_gitops_add_cluster_kubeconfig_pattern: "*kubeconfig*"
+----

--- a/roles/ocp4_workload_gitops_add_cluster/tasks/add_cluster_from_kubeconfig.yml
+++ b/roles/ocp4_workload_gitops_add_cluster/tasks/add_cluster_from_kubeconfig.yml
@@ -1,0 +1,101 @@
+---
+- name: "{{ _kubeconfig_path }} - Read kubeconfig content"
+  become: true
+  delegate_to: "{{ groups['bastions'][0] }}"
+  ansible.builtin.slurp:
+    src: "{{ _kubeconfig_path }}"
+  register: _kubeconfig_raw
+
+- name: "{{ _kubeconfig_path }} - Parse kubeconfig"
+  ansible.builtin.set_fact:
+    _ocp4_workload_gitops_add_cluster_kubeconfig: >-
+      {{ _kubeconfig_raw.content | b64decode | from_yaml }}
+
+# 1. Initialize the fact as an empty list
+- name: Initialize cluster info list
+  ansible.builtin.set_fact:
+    _ocp4_workload_gitops_add_cluster_cluster_info: []
+
+# 2. Build the flat list from the nested kubeconfig data
+- name: "{{ _kubeconfig_path }} - Build cluster info with credentials"
+  vars:
+    # Find the user name associated with this cluster in the contexts
+    _user_name: >-
+      {{ (_ocp4_workload_gitops_add_cluster_kubeconfig.contexts
+          | selectattr('context.cluster', 'equalto', item.name)
+          | map(attribute='context.user')
+          | first) | default('') }}
+    # Find the credential data for that specific user
+    _user_entry: >-
+      {{ (_ocp4_workload_gitops_add_cluster_kubeconfig.users
+          | selectattr('name', 'equalto', _user_name)
+          | map(attribute='user')
+          | first) | default({}) }}
+  ansible.builtin.set_fact:
+    _ocp4_workload_gitops_add_cluster_cluster_info: >-
+      {{ _ocp4_workload_gitops_add_cluster_cluster_info + [
+        {
+          'name': item.name,
+          'server': item.cluster.server,
+          'ca_data': item.cluster['certificate-authority-data'] | default(''),
+          'token': _user_entry.token | default(''),
+          'client_certificate_data': _user_entry['client-certificate-data'] | default(''),
+          'client_key_data': _user_entry['client-key-data'] | default('')
+        }
+      ] }}
+  # Fixed loop: Using 'name' for the unique filter as it's at the top level of the cluster object
+  loop: "{{ _ocp4_workload_gitops_add_cluster_kubeconfig.clusters | unique(attribute='name') }}"
+  loop_control:
+    label: "{{ item.name }} -> {{ item.cluster.server }}"
+
+# 3. Debug output
+- name: "{{ _kubeconfig_path }} - Report discovered clusters"
+  ansible.builtin.debug:
+    msg: "{{ item.name }} -> {{ item.server }}"
+  loop: "{{ _ocp4_workload_gitops_add_cluster_cluster_info }}"
+  loop_control:
+    label: "{{ item.name }}"
+
+- name: "{{ _kubeconfig_path }} - Create ArgoCD cluster secret for new clusters"
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: "cluster-{{ item.server | regex_replace('https?://', '') | regex_replace('[^a-zA-Z0-9-]', '-') }}"
+        namespace: "{{ ocp4_workload_gitops_add_cluster_argocd_namespace }}"
+        labels:
+          argocd.argoproj.io/secret-type: cluster
+          apps.open-cluster-management.io/cluster-name: "{{ item.name.split('-',2)[2] | default(item.name) }}"
+          argocd.argoproj.io/controller-shardid: "0"
+      type: Opaque
+      stringData:
+        name: "{{ item.name.split('-',2)[2] | default(item.name) }}"
+        server: "{{ item.server }}"
+        # The 'config' value MUST be a string.
+        # We build a dictionary and convert the whole thing to a JSON string.
+        config: >-
+          {{ {
+          "tlsClientConfig": {
+            "insecure": ocp4_workload_gitops_add_cluster_cluster_insecure | bool,
+            "certData": item.client_certificate_data | default(""),
+            "keyData": item.client_key_data | default(""),
+            "caData": item.ca_data | default("")
+          }} | to_json }}
+  when: item.server not in _ocp4_workload_gitops_add_cluster_existing_clusters
+  loop: "{{ _ocp4_workload_gitops_add_cluster_cluster_info }}"
+  loop_control:
+    label: "{{ item.name }} -> {{ item.server }}"
+
+- name: "{{ _kubeconfig_path }} - Report skipped clusters (already registered)"
+  ansible.builtin.debug:
+    msg: "Skipped {{ item.name }} ({{ item.server }}) - already registered in ArgoCD or is hub cluster"
+  when: item.server in _ocp4_workload_gitops_add_cluster_existing_clusters
+  loop: "{{ _ocp4_workload_gitops_add_cluster_cluster_info }}"
+  loop_control:
+    label: "{{ item.name }}"
+
+- name: Reset cluster info for next kubeconfig
+  ansible.builtin.set_fact:
+    _ocp4_workload_gitops_add_cluster_cluster_info: []

--- a/roles/ocp4_workload_gitops_add_cluster/tasks/main.yml
+++ b/roles/ocp4_workload_gitops_add_cluster/tasks/main.yml
@@ -1,0 +1,11 @@
+---
+# --------------------------------------------------
+# Do not modify this file
+# --------------------------------------------------
+- name: Running workload provision tasks
+  when: ACTION == "provision"
+  ansible.builtin.include_tasks: workload.yml
+
+- name: Running workload removal tasks
+  when: ACTION == "destroy"
+  ansible.builtin.include_tasks: remove_workload.yml

--- a/roles/ocp4_workload_gitops_add_cluster/tasks/remove_workload.yml
+++ b/roles/ocp4_workload_gitops_add_cluster/tasks/remove_workload.yml
@@ -1,0 +1,6 @@
+---
+- name: Remove discovered clusters from ArgoCD
+  ansible.builtin.debug:
+    msg: >-
+      Cluster removal is not implemented.
+      Remove clusters manually from ArgoCD if needed.

--- a/roles/ocp4_workload_gitops_add_cluster/tasks/workload.yml
+++ b/roles/ocp4_workload_gitops_add_cluster/tasks/workload.yml
@@ -1,0 +1,76 @@
+---
+- name: Get existing ArgoCD cluster secrets
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: Secret
+    namespace: "{{ ocp4_workload_gitops_add_cluster_argocd_namespace }}"
+    label_selectors:
+      - "argocd.argoproj.io/secret-type=cluster"
+  register: _argocd_cluster_secrets
+
+- name: Set list of existing ArgoCD cluster server URLs
+  ansible.builtin.set_fact:
+    _ocp4_workload_gitops_add_cluster_existing_clusters: >-
+      {{ _argocd_cluster_secrets.resources
+         | map(attribute='data')
+         | map(attribute='server')
+         | map('b64decode')
+         | list
+         + [openshift_api_url] }}
+
+- name: Report existing ArgoCD clusters (includes hub cluster API URL)
+  ansible.builtin.debug:
+    msg: "Clusters already in ArgoCD or hub: {{ _ocp4_workload_gitops_add_cluster_existing_clusters }}"
+
+# --- Kubeconfig discovery from bastion ---
+
+- name: Find kubeconfig files on bastion
+  delegate_to: "{{ groups['bastions'][0] }}"
+  become: true
+  ansible.builtin.find:
+    paths: "{{ ocp4_workload_gitops_add_cluster_kubeconfig_dir }}"
+    patterns: "{{ ocp4_workload_gitops_add_cluster_kubeconfig_pattern }}"
+    file_type: file
+    recurse: true
+  register: _kubeconfig_files
+
+- name: Report discovered kubeconfig files
+  delegate_to: "{{ groups['bastions'][0] }}"
+  become: true
+  ansible.builtin.find:
+    paths: "{{ ocp4_workload_gitops_add_cluster_kubeconfig_dir }}"
+    patterns: "{{ ocp4_workload_gitops_add_cluster_kubeconfig_pattern }}"
+    file_type: file
+    recurse: true
+  register: _kubeconfig_files
+- name: Report discovered kubeconfig files
+  ansible.builtin.debug:
+    msg: "Found kubeconfig files: {{ _kubeconfig_files.files | map(attribute='path') | list }}"
+
+- name: Process each kubeconfig file
+  when: _kubeconfig_files.files | length > 0
+  ansible.builtin.include_tasks: add_cluster_from_kubeconfig.yml
+  loop: "{{ _kubeconfig_files.files | map(attribute='path') | list }}"
+  loop_control:
+    loop_var: _kubeconfig_path
+
+- name: Fetch files to the controller
+  delegate_to: "{{ groups['bastions'][0] }}"
+  become: true
+  ansible.builtin.fetch:
+    src: "{{ item.path }}"
+    dest: "{{ output_dir }}/"
+  loop: "{{ _kubeconfig_files.files }}"
+  register: _controller_kubeconfig_files
+
+# incredibly frustrating.  This is the only way to get the node names.
+# kube connection caching is nearly impossible to override
+- name: Get node names using kubectl command
+  ansible.builtin.command:
+    cmd: "kubectl get nodes --kubeconfig={{ item.dest }} -o jsonpath='{.items[*].metadata.name}'"
+  loop: "{{ _controller_kubeconfig_files.results }}"
+  register: _nodes
+
+- name: Set fact of all node names
+  ansible.builtin.set_fact:
+    ocp4_workload_gitops_add_cluster_all_node_names: "{{ _nodes.results | map(attribute='stdout') | list }}"

--- a/roles/ocp4_workload_gitops_add_cluster/vars/main.yml
+++ b/roles/ocp4_workload_gitops_add_cluster/vars/main.yml
@@ -1,0 +1,4 @@
+---
+_ocp4_workload_gitops_add_cluster_kubeconfig: {}
+_ocp4_workload_gitops_add_cluster_cluster_info: []
+_ocp4_workload_gitops_add_cluster_existing_clusters: []


### PR DESCRIPTION
this is designed for multisno deployments, looks at the bastion for kubeconfig files.

Add the clusters found to argo on the primary cluster.

Also sets fact for the names of the nodes for later use through gitops_bootstrap to argo helm charts.