### PR TITLE
Add ocp4_workload_garage role for Garage S3-compatible storage

### DIFF
--- a/roles/ocp4_workload_garage/defaults/main.yml
+++ b/roles/ocp4_workload_garage/defaults/main.yml
@@ -59,6 +59,7 @@ ocp4_workload_garage_web_route_tls_insecure_policy: Redirect
 
 # Post-deploy: API key and buckets
 ocp4_workload_garage_key_name: garage-api-key
+ocp4_workload_garage_credentials_secret: garage-s3-credentials
 ocp4_workload_garage_buckets: []
 
 # Catch-all for arbitrary Helm values (merged last, can override anything)

--- a/roles/ocp4_workload_garage/defaults/main.yml
+++ b/roles/ocp4_workload_garage/defaults/main.yml
@@ -61,6 +61,3 @@ ocp4_workload_garage_sync_retry_limit: 5
 # User info configuration
 ocp4_workload_garage_enable_user_info_messages: true
 ocp4_workload_garage_enable_user_info_data: true
-
-# Wait for deployment readiness
-ocp4_workload_garage_wait_for_deployment: true

--- a/roles/ocp4_workload_garage/defaults/main.yml
+++ b/roles/ocp4_workload_garage/defaults/main.yml
@@ -51,7 +51,7 @@ ocp4_workload_garage_s3_api_route_tls_termination: edge
 ocp4_workload_garage_s3_api_route_tls_insecure_policy: Redirect
 
 # Web UI Route (port 3902)
-ocp4_workload_garage_web_route_enabled: false
+ocp4_workload_garage_web_route_enabled: true
 ocp4_workload_garage_web_route_host: ""
 ocp4_workload_garage_web_route_tls_termination: edge
 ocp4_workload_garage_web_route_tls_insecure_policy: Redirect

--- a/roles/ocp4_workload_garage/defaults/main.yml
+++ b/roles/ocp4_workload_garage/defaults/main.yml
@@ -13,6 +13,11 @@ ocp4_workload_garage_chart_repo: https://git.deuxfleurs.fr/Deuxfleurs/garage
 ocp4_workload_garage_chart_revision: main-v1
 ocp4_workload_garage_chart_path: script/helm/garage
 
+# Image configuration (empty tag defaults to chart's appVersion)
+ocp4_workload_garage_image_repository: dxflrs/amd64_garage
+ocp4_workload_garage_image_tag: ""
+ocp4_workload_garage_image_pull_policy: IfNotPresent
+
 # Garage configuration
 # Number of StatefulSet pods
 ocp4_workload_garage_replicas: 1

--- a/roles/ocp4_workload_garage/defaults/main.yml
+++ b/roles/ocp4_workload_garage/defaults/main.yml
@@ -22,8 +22,10 @@ ocp4_workload_garage_image_pull_policy: IfNotPresent
 # Number of StatefulSet pods
 ocp4_workload_garage_replicas: 1
 # Number of copies of each object stored across nodes. Must be <= replicas.
-# "1" = no redundancy (testing only), "2" = tolerates 1 node failure, "3" = tolerates 2 node failures.
-ocp4_workload_garage_replication_mode: "1"
+# 1 = no redundancy (testing only), 2 = tolerates 1 node failure, 3 = tolerates 2 node failures.
+ocp4_workload_garage_replication_factor: 1
+# Read/write quorum behavior: "consistent" (default), "degraded", or "dangerous"
+ocp4_workload_garage_consistency_mode: consistent
 # Database engine for metadata: "lmdb" (recommended) or "sqlite"
 ocp4_workload_garage_db_engine: lmdb
 ocp4_workload_garage_s3_region: garage

--- a/roles/ocp4_workload_garage/defaults/main.yml
+++ b/roles/ocp4_workload_garage/defaults/main.yml
@@ -14,8 +14,12 @@ ocp4_workload_garage_chart_revision: main-v1
 ocp4_workload_garage_chart_path: script/helm/garage
 
 # Garage configuration
+# Number of StatefulSet pods
 ocp4_workload_garage_replicas: 1
+# Number of copies of each object stored across nodes. Must be <= replicas.
+# "1" = no redundancy (testing only), "2" = tolerates 1 node failure, "3" = tolerates 2 node failures.
 ocp4_workload_garage_replication_mode: "1"
+# Database engine for metadata: "lmdb" (recommended) or "sqlite"
 ocp4_workload_garage_db_engine: lmdb
 ocp4_workload_garage_s3_region: garage
 

--- a/roles/ocp4_workload_garage/defaults/main.yml
+++ b/roles/ocp4_workload_garage/defaults/main.yml
@@ -50,8 +50,9 @@ ocp4_workload_garage_s3_api_route_host: ""
 ocp4_workload_garage_s3_api_route_tls_termination: edge
 ocp4_workload_garage_s3_api_route_tls_insecure_policy: Redirect
 
-# Web UI Route (port 3902)
-ocp4_workload_garage_web_route_enabled: true
+# Web Route (port 3902) - serves static websites from S3 buckets, not an admin UI.
+# Only useful if hosting web content from buckets with a configured root domain.
+ocp4_workload_garage_web_route_enabled: false
 ocp4_workload_garage_web_route_host: ""
 ocp4_workload_garage_web_route_tls_termination: edge
 ocp4_workload_garage_web_route_tls_insecure_policy: Redirect

--- a/roles/ocp4_workload_garage/defaults/main.yml
+++ b/roles/ocp4_workload_garage/defaults/main.yml
@@ -1,0 +1,66 @@
+---
+# Garage (S3-compatible distributed object storage) workload configuration
+
+# Namespace
+ocp4_workload_garage_namespace: garage
+
+# ArgoCD Application configuration
+ocp4_workload_garage_application_name: garage
+ocp4_workload_garage_gitops_namespace: openshift-gitops
+
+# Helm chart source
+ocp4_workload_garage_chart_repo: https://git.deuxfleurs.fr/Deuxfleurs/garage
+ocp4_workload_garage_chart_revision: main-v1
+ocp4_workload_garage_chart_path: script/helm/garage
+
+# Garage configuration
+ocp4_workload_garage_replicas: 1
+ocp4_workload_garage_replication_mode: "1"
+ocp4_workload_garage_db_engine: lmdb
+ocp4_workload_garage_s3_region: garage
+
+# Storage - metadata
+ocp4_workload_garage_storage_meta_size: 1Gi
+ocp4_workload_garage_storage_meta_storage_class: ""
+
+# Storage - data
+ocp4_workload_garage_storage_data_size: 10Gi
+ocp4_workload_garage_storage_data_storage_class: ""
+
+# Resource limits
+ocp4_workload_garage_resources_requests_cpu: 100m
+ocp4_workload_garage_resources_requests_memory: 256Mi
+ocp4_workload_garage_resources_limits_cpu: 1000m
+ocp4_workload_garage_resources_limits_memory: 1Gi
+
+# S3 API Route (port 3900)
+ocp4_workload_garage_s3_api_route_enabled: true
+ocp4_workload_garage_s3_api_route_host: ""
+ocp4_workload_garage_s3_api_route_tls_termination: edge
+ocp4_workload_garage_s3_api_route_tls_insecure_policy: Redirect
+
+# Web UI Route (port 3902)
+ocp4_workload_garage_web_route_enabled: false
+ocp4_workload_garage_web_route_host: ""
+ocp4_workload_garage_web_route_tls_termination: edge
+ocp4_workload_garage_web_route_tls_insecure_policy: Redirect
+
+# Post-deploy: API key and buckets
+ocp4_workload_garage_key_name: garage-api-key
+ocp4_workload_garage_buckets: []
+
+# Catch-all for arbitrary Helm values (merged last, can override anything)
+ocp4_workload_garage_helm_values: {}
+
+# ArgoCD sync configuration
+ocp4_workload_garage_sync_policy_automated: true
+ocp4_workload_garage_sync_policy_self_heal: true
+ocp4_workload_garage_sync_policy_prune: true
+ocp4_workload_garage_sync_retry_limit: 5
+
+# User info configuration
+ocp4_workload_garage_enable_user_info_messages: true
+ocp4_workload_garage_enable_user_info_data: true
+
+# Wait for deployment readiness
+ocp4_workload_garage_wait_for_deployment: true

--- a/roles/ocp4_workload_garage/meta/main.yml
+++ b/roles/ocp4_workload_garage/meta/main.yml
@@ -1,0 +1,18 @@
+---
+galaxy_info:
+  role_name: ocp4_workload_garage
+  author: Red Hat GPTE
+  description: >-
+    Deploy Garage S3-compatible distributed object storage on OpenShift using GitOps.
+  license: MIT
+  min_ansible_version: "2.9"
+  platforms: []
+  galaxy_tags:
+  - ocp
+  - openshift
+  - s3
+  - storage
+  - gitops
+  - argocd
+  - garage
+dependencies: []

--- a/roles/ocp4_workload_garage/readme.adoc
+++ b/roles/ocp4_workload_garage/readme.adoc
@@ -47,7 +47,8 @@ The role performs the following tasks:
 === Garage Configuration
 
 * `ocp4_workload_garage_replicas`: Number of StatefulSet replicas (default: `1`)
-* `ocp4_workload_garage_replication_mode`: Number of copies per object, must be `<= replicas` (default: `"1"`)
+* `ocp4_workload_garage_replication_factor`: Number of copies per object, must be `<= replicas` (default: `1`)
+* `ocp4_workload_garage_consistency_mode`: Read/write quorum behavior: `consistent`, `degraded`, or `dangerous` (default: `consistent`)
 * `ocp4_workload_garage_db_engine`: Database engine: `lmdb` or `sqlite` (default: `lmdb`)
 * `ocp4_workload_garage_s3_region`: S3 region name (default: `garage`)
 
@@ -135,7 +136,7 @@ The role performs the following tasks:
       name: ocp4_workload_garage
     vars:
       ocp4_workload_garage_replicas: 3
-      ocp4_workload_garage_replication_mode: "2"
+      ocp4_workload_garage_replication_factor: 2
       ocp4_workload_garage_storage_data_size: 50Gi
       ocp4_workload_garage_storage_data_storage_class: ocs-storagecluster-ceph-rbd
       ocp4_workload_garage_buckets:

--- a/roles/ocp4_workload_garage/readme.adoc
+++ b/roles/ocp4_workload_garage/readme.adoc
@@ -1,0 +1,235 @@
+= ocp4_workload_garage - Deploy Garage S3-Compatible Object Storage
+
+== Role overview
+
+* This role deploys https://garagehq.deuxfleurs.fr/[Garage] on OpenShift using GitOps/ArgoCD
+* Garage provides S3-compatible distributed object storage
+* Supports multi-node deployments with configurable replication
+* Includes optional automatic API key and bucket creation
+
+== Features
+
+* GitOps-based deployment using OpenShift GitOps (ArgoCD)
+* S3-compatible API endpoint (port 3900)
+* Optional web interface (port 3902)
+* Distributed architecture with configurable replication
+* Automatic API key and bucket provisioning via built-in CLI
+* OpenShift Route integration for external access
+* Catch-all Helm values variable for full customization
+
+== Deployment
+
+This role assumes OpenShift GitOps is already installed in the `openshift-gitops` namespace.
+
+The role performs the following tasks:
+
+* Creates the Garage namespace (default: `garage`)
+* Deploys an ArgoCD Application resource pointing to the Garage Helm chart
+* Waits for the Application to sync and StatefulSet to be ready
+* Creates OpenShift Routes for S3 API and optionally web UI
+* Optionally creates an API key and S3 buckets via `garage` CLI
+* Reports access information to users (endpoints, credentials)
+
+== Variables
+
+=== Namespace Configuration
+
+* `ocp4_workload_garage_namespace`: Namespace for Garage deployment (default: `garage`)
+
+=== ArgoCD Configuration
+
+* `ocp4_workload_garage_application_name`: ArgoCD Application name (default: `garage`)
+* `ocp4_workload_garage_gitops_namespace`: OpenShift GitOps namespace (default: `openshift-gitops`)
+* `ocp4_workload_garage_chart_repo`: Helm chart repository URL (default: `https://git.deuxfleurs.fr/Deuxfleurs/garage`)
+* `ocp4_workload_garage_chart_revision`: Git branch/tag (default: `main-v1`)
+* `ocp4_workload_garage_chart_path`: Path to chart in repo (default: `script/helm/garage`)
+
+=== Garage Configuration
+
+* `ocp4_workload_garage_replicas`: Number of StatefulSet replicas (default: `1`)
+* `ocp4_workload_garage_replication_mode`: Number of copies per object, must be `<= replicas` (default: `"1"`)
+* `ocp4_workload_garage_db_engine`: Database engine: `lmdb` or `sqlite` (default: `lmdb`)
+* `ocp4_workload_garage_s3_region`: S3 region name (default: `garage`)
+
+=== Storage Configuration
+
+* `ocp4_workload_garage_storage_meta_size`: Metadata volume size (default: `1Gi`)
+* `ocp4_workload_garage_storage_meta_storage_class`: Storage class for metadata (default: empty = default class)
+* `ocp4_workload_garage_storage_data_size`: Data volume size (default: `10Gi`)
+* `ocp4_workload_garage_storage_data_storage_class`: Storage class for data (default: empty = default class)
+
+=== Resource Limits
+
+* `ocp4_workload_garage_resources_requests_cpu`: CPU request (default: `100m`)
+* `ocp4_workload_garage_resources_requests_memory`: Memory request (default: `256Mi`)
+* `ocp4_workload_garage_resources_limits_cpu`: CPU limit (default: `1000m`)
+* `ocp4_workload_garage_resources_limits_memory`: Memory limit (default: `1Gi`)
+
+=== Route Configuration
+
+* `ocp4_workload_garage_s3_api_route_enabled`: Enable Route for S3 API (default: `true`)
+* `ocp4_workload_garage_s3_api_route_host`: Custom hostname (default: auto-generated)
+* `ocp4_workload_garage_s3_api_route_tls_termination`: TLS termination (default: `edge`)
+* `ocp4_workload_garage_s3_api_route_tls_insecure_policy`: Insecure policy (default: `Redirect`)
+* `ocp4_workload_garage_web_route_enabled`: Enable Route for web UI (default: `false`)
+* `ocp4_workload_garage_web_route_host`: Custom hostname (default: auto-generated)
+
+=== API Key and Bucket Creation
+
+* `ocp4_workload_garage_key_name`: Name of the API key to create (default: `garage-api-key`)
+* `ocp4_workload_garage_buckets`: List of S3 bucket names to create (default: `[]`)
+** Example: `['datasets', 'ml-models', 'backups']`
+
+=== Custom Helm Values
+
+* `ocp4_workload_garage_helm_values`: Dictionary of arbitrary Helm values merged last (default: `{}`)
+** These override any values set by explicit variables above
+** See the Garage Helm chart for all available options
+
+=== Sync Policy
+
+* `ocp4_workload_garage_sync_policy_automated`: Enable automated sync (default: `true`)
+* `ocp4_workload_garage_sync_policy_self_heal`: Enable self-healing (default: `true`)
+* `ocp4_workload_garage_sync_policy_prune`: Enable resource pruning (default: `true`)
+
+== Example Usage
+
+=== Basic Deployment
+
+[source,yaml]
+----
+- name: Deploy Garage
+  hosts: localhost
+  tasks:
+  - name: Include Garage workload
+    include_role:
+      name: ocp4_workload_garage
+----
+
+=== With Bucket Creation
+
+[source,yaml]
+----
+- name: Deploy Garage with buckets
+  hosts: localhost
+  tasks:
+  - name: Include Garage workload
+    include_role:
+      name: ocp4_workload_garage
+    vars:
+      ocp4_workload_garage_buckets:
+      - my-data-bucket
+      - ml-models
+      - datasets
+----
+
+=== Multi-Node with Replication
+
+[source,yaml]
+----
+- name: Deploy Garage with replication
+  hosts: localhost
+  tasks:
+  - name: Include Garage workload
+    include_role:
+      name: ocp4_workload_garage
+    vars:
+      ocp4_workload_garage_replicas: 3
+      ocp4_workload_garage_replication_mode: "2"
+      ocp4_workload_garage_storage_data_size: 50Gi
+      ocp4_workload_garage_storage_data_storage_class: ocs-storagecluster-ceph-rbd
+      ocp4_workload_garage_buckets:
+      - production-data
+----
+
+=== Custom Helm Values
+
+[source,yaml]
+----
+- name: Deploy Garage with custom Helm overrides
+  hosts: localhost
+  tasks:
+  - name: Include Garage workload
+    include_role:
+      name: ocp4_workload_garage
+    vars:
+      ocp4_workload_garage_helm_values:
+        garage:
+          compressionLevel: "3"
+          blockSize: "1048576"
+        monitoring:
+          metrics:
+            enabled: true
+          serviceMonitor:
+            enabled: true
+----
+
+== Accessing Garage
+
+After deployment, users will receive:
+
+* *S3 Endpoint (internal)*: For pod-to-pod communication within the cluster
+* *S3 Endpoint (external)*: Via OpenShift Route (if enabled)
+* *S3 Access Key*: For S3 API authentication
+* *S3 Secret Key*: For S3 API authentication
+* *Web UI URL*: If web route is enabled
+
+== Using S3 API
+
+You can use any S3-compatible client (AWS CLI, boto3, mc, etc.):
+
+[source,bash]
+----
+# Using AWS CLI
+aws configure set aws_access_key_id <access-key>
+aws configure set aws_secret_access_key <secret-key>
+aws --endpoint-url https://<s3-route-url> s3 ls
+aws --endpoint-url https://<s3-route-url> s3 cp file.txt s3://my-bucket/
+
+# Using MinIO Client (mc)
+mc alias set mygarage https://<s3-route-url> <access-key> <secret-key>
+mc ls mygarage
+mc cp file.txt mygarage/my-bucket/
+----
+
+== Removal
+
+To remove the Garage deployment:
+
+[source,yaml]
+----
+- name: Remove Garage
+  hosts: localhost
+  tasks:
+  - name: Include Garage workload
+    include_role:
+      name: ocp4_workload_garage
+    vars:
+      ACTION: destroy
+----
+
+This will:
+
+* Delete OpenShift Routes
+* Delete the ArgoCD Application (which removes all Garage resources)
+* Delete the Garage namespace
+
+NOTE: Removing the workload will delete the PVCs and all data unless you have external backups.
+
+== Garage Architecture
+
+Garage is a distributed object storage system designed for self-hosting:
+
+* *S3 API*: S3-compatible API on port 3900
+* *Web Endpoint*: Static website hosting on port 3902
+* *RPC*: Inter-node communication on port 3901
+* *Admin API*: Cluster management on port 3903
+* *LMDB/SQLite*: Metadata storage engine
+* *Kubernetes Discovery*: Automatic node discovery via CRD
+
+The deployment uses:
+
+* Kubernetes StatefulSet (supports multiple replicas)
+* PersistentVolumeClaims for metadata and data storage
+* OpenShift Routes for external access
+* Service for internal cluster access

--- a/roles/ocp4_workload_garage/tasks/main.yml
+++ b/roles/ocp4_workload_garage/tasks/main.yml
@@ -1,0 +1,8 @@
+---
+- name: Running workload provision tasks
+  when: ACTION == "provision"
+  ansible.builtin.include_tasks: workload.yml
+
+- name: Running workload removal tasks
+  when: ACTION == "destroy"
+  ansible.builtin.include_tasks: remove_workload.yml

--- a/roles/ocp4_workload_garage/tasks/main.yml
+++ b/roles/ocp4_workload_garage/tasks/main.yml
@@ -1,4 +1,7 @@
 ---
+# --------------------------------------------------
+# Do not modify this file
+# --------------------------------------------------
 - name: Running workload provision tasks
   when: ACTION == "provision"
   ansible.builtin.include_tasks: workload.yml

--- a/roles/ocp4_workload_garage/tasks/remove_workload.yml
+++ b/roles/ocp4_workload_garage/tasks/remove_workload.yml
@@ -1,0 +1,52 @@
+---
+- name: Delete S3 API Route
+  kubernetes.core.k8s:
+    state: absent
+    api_version: route.openshift.io/v1
+    kind: Route
+    name: garage-s3-api
+    namespace: "{{ ocp4_workload_garage_namespace }}"
+
+- name: Delete Web UI Route
+  kubernetes.core.k8s:
+    state: absent
+    api_version: route.openshift.io/v1
+    kind: Route
+    name: garage-web
+    namespace: "{{ ocp4_workload_garage_namespace }}"
+
+- name: Delete ArgoCD Application
+  kubernetes.core.k8s:
+    state: absent
+    api_version: argoproj.io/v1alpha1
+    kind: Application
+    name: "{{ ocp4_workload_garage_application_name }}"
+    namespace: "{{ ocp4_workload_garage_gitops_namespace }}"
+
+- name: Wait for Application deletion
+  kubernetes.core.k8s_info:
+    api_version: argoproj.io/v1alpha1
+    kind: Application
+    name: "{{ ocp4_workload_garage_application_name }}"
+    namespace: "{{ ocp4_workload_garage_gitops_namespace }}"
+  register: r_application
+  retries: 30
+  delay: 10
+  until: r_application.resources | length == 0
+
+- name: Delete Garage namespace
+  kubernetes.core.k8s:
+    state: absent
+    api_version: v1
+    kind: Namespace
+    name: "{{ ocp4_workload_garage_namespace }}"
+
+- name: Wait for namespace deletion
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: Namespace
+    name: "{{ ocp4_workload_garage_namespace }}"
+  register: r_namespace
+  retries: 60
+  delay: 5
+  until: r_namespace.resources | length == 0

--- a/roles/ocp4_workload_garage/tasks/remove_workload.yml
+++ b/roles/ocp4_workload_garage/tasks/remove_workload.yml
@@ -4,7 +4,7 @@
     state: absent
     api_version: route.openshift.io/v1
     kind: Route
-    name: garage-s3-api
+    name: s3
     namespace: "{{ ocp4_workload_garage_namespace }}"
 
 - name: Delete Web UI Route
@@ -12,7 +12,7 @@
     state: absent
     api_version: route.openshift.io/v1
     kind: Route
-    name: garage-web
+    name: garage
     namespace: "{{ ocp4_workload_garage_namespace }}"
 
 - name: Delete ArgoCD Application

--- a/roles/ocp4_workload_garage/tasks/workload.yml
+++ b/roles/ocp4_workload_garage/tasks/workload.yml
@@ -86,7 +86,7 @@
     register: r_garage_layout
 
   - name: Assign and apply cluster layout
-    when: "'NO ROLE ASSIGNED' in r_garage_layout.stdout"
+    when: "'No nodes currently have a role' in r_garage_layout.stdout"
     block:
     - name: Assign nodes to cluster layout
       kubernetes.core.k8s_exec:

--- a/roles/ocp4_workload_garage/tasks/workload.yml
+++ b/roles/ocp4_workload_garage/tasks/workload.yml
@@ -78,26 +78,32 @@
         | regex_findall('([0-9a-f]{16})\s+.*garage-\d+')
         | list }}
 
-  - name: Assign nodes to cluster layout
+  - name: Check if nodes already have roles assigned
     kubernetes.core.k8s_exec:
       namespace: "{{ ocp4_workload_garage_namespace }}"
       pod: "{{ _ocp4_workload_garage_service_name }}-0"
-      command: >-
-        ./garage layout assign -z dc1
-        -c {{ ocp4_workload_garage_storage_data_size }}
-        {{ item }}
-    loop: "{{ _ocp4_workload_garage_node_ids }}"
+      command: ./garage layout show
+    register: r_garage_layout
 
-  - name: Apply cluster layout
-    kubernetes.core.k8s_exec:
-      namespace: "{{ ocp4_workload_garage_namespace }}"
-      pod: "{{ _ocp4_workload_garage_service_name }}-0"
-      command: ./garage layout apply --version 1
-    register: r_layout_apply
-    failed_when:
-    - r_layout_apply.rc != 0
-    - "'already up to date' not in r_layout_apply.stderr"
-    - "'already up to date' not in r_layout_apply.stdout"
+  - name: Assign and apply cluster layout
+    when: "'NO ROLE ASSIGNED' in r_garage_layout.stdout"
+    block:
+    - name: Assign nodes to cluster layout
+      kubernetes.core.k8s_exec:
+        namespace: "{{ ocp4_workload_garage_namespace }}"
+        pod: "{{ _ocp4_workload_garage_service_name }}-0"
+        command: >-
+          ./garage layout assign -z dc1
+          -c {{ ocp4_workload_garage_storage_data_size }}
+          {{ item }}
+      loop: "{{ _ocp4_workload_garage_node_ids }}"
+
+    - name: Apply cluster layout
+      kubernetes.core.k8s_exec:
+        namespace: "{{ ocp4_workload_garage_namespace }}"
+        pod: "{{ _ocp4_workload_garage_service_name }}-0"
+        command: ./garage layout apply --version 1
+      register: r_layout_apply
 
 - name: Create S3 API Route
   when: ocp4_workload_garage_s3_api_route_enabled | bool

--- a/roles/ocp4_workload_garage/tasks/workload.yml
+++ b/roles/ocp4_workload_garage/tasks/workload.yml
@@ -76,7 +76,7 @@
   kubernetes.core.k8s_info:
     api_version: route.openshift.io/v1
     kind: Route
-    name: garage-s3-api
+    name: s3
     namespace: "{{ ocp4_workload_garage_namespace }}"
   register: r_garage_s3_route
   retries: 30

--- a/roles/ocp4_workload_garage/tasks/workload.yml
+++ b/roles/ocp4_workload_garage/tasks/workload.yml
@@ -59,6 +59,46 @@
   - r_garage_statefulset.resources[0].status.readyReplicas is defined
   - r_garage_statefulset.resources[0].status.readyReplicas | int == ocp4_workload_garage_replicas | int
 
+- name: Configure Garage cluster layout
+  block:
+  - name: Get Garage node IDs
+    kubernetes.core.k8s_exec:
+      namespace: "{{ ocp4_workload_garage_namespace }}"
+      pod: "{{ _ocp4_workload_garage_service_name }}-0"
+      command: ./garage status
+    register: r_garage_status
+    retries: 10
+    delay: 5
+    until: r_garage_status is success
+
+  - name: Extract node IDs from status output
+    ansible.builtin.set_fact:
+      _ocp4_workload_garage_node_ids: >-
+        {{ r_garage_status.stdout
+        | regex_findall('([0-9a-f]{16})\s+.*garage-\d+')
+        | list }}
+
+  - name: Assign nodes to cluster layout
+    kubernetes.core.k8s_exec:
+      namespace: "{{ ocp4_workload_garage_namespace }}"
+      pod: "{{ _ocp4_workload_garage_service_name }}-0"
+      command: >-
+        ./garage layout assign -z dc1
+        -c {{ ocp4_workload_garage_storage_data_size }}
+        {{ item }}
+    loop: "{{ _ocp4_workload_garage_node_ids }}"
+
+  - name: Apply cluster layout
+    kubernetes.core.k8s_exec:
+      namespace: "{{ ocp4_workload_garage_namespace }}"
+      pod: "{{ _ocp4_workload_garage_service_name }}-0"
+      command: ./garage layout apply --version 1
+    register: r_layout_apply
+    failed_when:
+    - r_layout_apply.rc != 0
+    - "'already up to date' not in r_layout_apply.stderr"
+    - "'already up to date' not in r_layout_apply.stdout"
+
 - name: Create S3 API Route
   when: ocp4_workload_garage_s3_api_route_enabled | bool
   kubernetes.core.k8s:

--- a/roles/ocp4_workload_garage/tasks/workload.yml
+++ b/roles/ocp4_workload_garage/tasks/workload.yml
@@ -185,6 +185,20 @@
       _ocp4_workload_garage_secret_key: >-
         {{ r_garage_key.stdout | regex_search('Secret key: (\S+)', '\1') | first }}
 
+  - name: Save Garage credentials to Secret
+    kubernetes.core.k8s:
+      state: present
+      definition:
+        apiVersion: v1
+        kind: Secret
+        metadata:
+          name: "{{ ocp4_workload_garage_credentials_secret }}"
+          namespace: "{{ ocp4_workload_garage_namespace }}"
+        type: Opaque
+        stringData:
+          access_key: "{{ _ocp4_workload_garage_access_key }}"
+          secret_key: "{{ _ocp4_workload_garage_secret_key }}"
+
   - name: Create Garage buckets
     when: ocp4_workload_garage_buckets | default([]) | length > 0
     kubernetes.core.k8s_exec:

--- a/roles/ocp4_workload_garage/tasks/workload.yml
+++ b/roles/ocp4_workload_garage/tasks/workload.yml
@@ -1,0 +1,194 @@
+---
+- name: Set internal variables
+  ansible.builtin.set_fact:
+    _ocp4_workload_garage_service_name: "{{ ocp4_workload_garage_application_name }}"
+    _ocp4_workload_garage_s3_endpoint_internal: >-
+      http://{{ ocp4_workload_garage_application_name }}.{{ ocp4_workload_garage_namespace }}.svc.cluster.local:3900
+    _ocp4_workload_garage_s3_endpoint_external: ""
+    _ocp4_workload_garage_web_url: ""
+    _ocp4_workload_garage_access_key: ""
+    _ocp4_workload_garage_secret_key: ""
+
+- name: Create Garage namespace
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: "{{ ocp4_workload_garage_namespace }}"
+        labels:
+          argocd.argoproj.io/managed-by: "{{ ocp4_workload_garage_gitops_namespace }}"
+
+- name: Create ArgoCD Application for Garage
+  kubernetes.core.k8s:
+    state: present
+    template: application.yaml.j2
+
+- name: Wait for Garage Application to sync
+  when: ocp4_workload_garage_wait_for_deployment | bool
+  kubernetes.core.k8s_info:
+    api_version: argoproj.io/v1alpha1
+    kind: Application
+    name: "{{ ocp4_workload_garage_application_name }}"
+    namespace: "{{ ocp4_workload_garage_gitops_namespace }}"
+  register: r_application
+  retries: 60
+  delay: 10
+  until:
+  - r_application.resources is defined
+  - r_application.resources | length > 0
+  - r_application.resources[0].status is defined
+  - r_application.resources[0].status.sync is defined
+  - r_application.resources[0].status.sync.status == 'Synced'
+  - r_application.resources[0].status.health is defined
+  - r_application.resources[0].status.health.status == 'Healthy'
+
+- name: Wait for Garage StatefulSet to be ready
+  when: ocp4_workload_garage_wait_for_deployment | bool
+  kubernetes.core.k8s_info:
+    api_version: apps/v1
+    kind: StatefulSet
+    name: "{{ _ocp4_workload_garage_service_name }}"
+    namespace: "{{ ocp4_workload_garage_namespace }}"
+  register: r_garage_statefulset
+  retries: 60
+  delay: 10
+  until:
+  - r_garage_statefulset.resources is defined
+  - r_garage_statefulset.resources | length > 0
+  - r_garage_statefulset.resources[0].status is defined
+  - r_garage_statefulset.resources[0].status.readyReplicas is defined
+  - r_garage_statefulset.resources[0].status.readyReplicas | int == ocp4_workload_garage_replicas | int
+
+- name: Create S3 API Route
+  when: ocp4_workload_garage_s3_api_route_enabled | bool
+  kubernetes.core.k8s:
+    state: present
+    template: route-s3-api.yaml.j2
+
+- name: Create Web UI Route
+  when: ocp4_workload_garage_web_route_enabled | bool
+  kubernetes.core.k8s:
+    state: present
+    template: route-web.yaml.j2
+
+- name: Get S3 API Route
+  when: ocp4_workload_garage_s3_api_route_enabled | bool
+  kubernetes.core.k8s_info:
+    api_version: route.openshift.io/v1
+    kind: Route
+    name: garage-s3-api
+    namespace: "{{ ocp4_workload_garage_namespace }}"
+  register: r_garage_s3_route
+  retries: 30
+  delay: 5
+  until:
+  - r_garage_s3_route.resources is defined
+  - r_garage_s3_route.resources | length > 0
+  - r_garage_s3_route.resources[0].spec.host is defined
+
+- name: Set S3 API endpoint URL
+  when:
+  - ocp4_workload_garage_s3_api_route_enabled | bool
+  - r_garage_s3_route.resources | length > 0
+  ansible.builtin.set_fact:
+    _ocp4_workload_garage_s3_endpoint_external: "https://{{ r_garage_s3_route.resources[0].spec.host }}"
+
+- name: Get Web UI Route
+  when: ocp4_workload_garage_web_route_enabled | bool
+  kubernetes.core.k8s_info:
+    api_version: route.openshift.io/v1
+    kind: Route
+    name: garage-web
+    namespace: "{{ ocp4_workload_garage_namespace }}"
+  register: r_garage_web_route
+  retries: 30
+  delay: 5
+  until:
+  - r_garage_web_route.resources is defined
+  - r_garage_web_route.resources | length > 0
+  - r_garage_web_route.resources[0].spec.host is defined
+
+- name: Set Web UI URL
+  when:
+  - ocp4_workload_garage_web_route_enabled | bool
+  - r_garage_web_route.resources | length > 0
+  ansible.builtin.set_fact:
+    _ocp4_workload_garage_web_url: "https://{{ r_garage_web_route.resources[0].spec.host }}"
+
+- name: Create API key and buckets
+  when: ocp4_workload_garage_key_name | length > 0
+  block:
+  - name: Create Garage API key
+    kubernetes.core.k8s_exec:
+      namespace: "{{ ocp4_workload_garage_namespace }}"
+      pod: "{{ _ocp4_workload_garage_service_name }}-0"
+      command: ./garage key create {{ ocp4_workload_garage_key_name }}
+    register: r_garage_key
+
+  - name: Set API key credentials
+    ansible.builtin.set_fact:
+      _ocp4_workload_garage_access_key: >-
+        {{ r_garage_key.stdout | regex_search('Key ID: (\S+)', '\1') | first }}
+      _ocp4_workload_garage_secret_key: >-
+        {{ r_garage_key.stdout | regex_search('Secret key: (\S+)', '\1') | first }}
+
+  - name: Create Garage buckets
+    when: ocp4_workload_garage_buckets | default([]) | length > 0
+    kubernetes.core.k8s_exec:
+      namespace: "{{ ocp4_workload_garage_namespace }}"
+      pod: "{{ _ocp4_workload_garage_service_name }}-0"
+      command: ./garage bucket create {{ bucket_name }}
+    loop: "{{ ocp4_workload_garage_buckets }}"
+    loop_control:
+      loop_var: bucket_name
+
+  - name: Grant key access to buckets
+    when: ocp4_workload_garage_buckets | default([]) | length > 0
+    kubernetes.core.k8s_exec:
+      namespace: "{{ ocp4_workload_garage_namespace }}"
+      pod: "{{ _ocp4_workload_garage_service_name }}-0"
+      command: >-
+        ./garage bucket allow --read --write
+        {{ bucket_name }} --key {{ ocp4_workload_garage_key_name }}
+    loop: "{{ ocp4_workload_garage_buckets }}"
+    loop_control:
+      loop_var: bucket_name
+
+- name: Report Garage information to user
+  when: ocp4_workload_garage_enable_user_info_messages | bool
+  block:
+  - name: Set Garage user info messages
+    ansible.builtin.set_fact:
+      _garage_user_info_messages:
+      - msg: "Garage S3 Endpoint (internal): {{ _ocp4_workload_garage_s3_endpoint_internal }}"
+        when: true
+      - msg: "Garage S3 Endpoint (external): {{ _ocp4_workload_garage_s3_endpoint_external }}"
+        when: "{{ _ocp4_workload_garage_s3_endpoint_external | length > 0 }}"
+      - msg: "Garage S3 Access Key: {{ _ocp4_workload_garage_access_key }}"
+        when: "{{ _ocp4_workload_garage_access_key | length > 0 }}"
+      - msg: "Garage S3 Secret Key: {{ _ocp4_workload_garage_secret_key }}"
+        when: "{{ _ocp4_workload_garage_access_key | length > 0 }}"
+      - msg: "Garage Web UI: {{ _ocp4_workload_garage_web_url }}"
+        when: "{{ _ocp4_workload_garage_web_url | length > 0 }}"
+      - msg: "Garage S3 Buckets Created: {{ ocp4_workload_garage_buckets | join(', ') }}"
+        when: "{{ ocp4_workload_garage_buckets | default([]) | length > 0 }}"
+
+  - name: Print Garage information
+    when: item.when | bool
+    agnosticd.core.agnosticd_user_info:
+      msg: "{{ item.msg }}"
+    loop: "{{ _garage_user_info_messages }}"
+
+- name: Save Garage data for user
+  when: ocp4_workload_garage_enable_user_info_data | bool
+  agnosticd.core.agnosticd_user_info:
+    data:
+      garage_s3_access_key_id: "{{ _ocp4_workload_garage_access_key }}"
+      garage_s3_secret_access_key: "{{ _ocp4_workload_garage_secret_key }}"
+      garage_s3_endpoint_internal: "{{ _ocp4_workload_garage_s3_endpoint_internal }}"
+      garage_s3_endpoint_external: "{{ _ocp4_workload_garage_s3_endpoint_external }}"
+      garage_web_url: "{{ _ocp4_workload_garage_web_url }}"
+      garage_buckets: "{{ ocp4_workload_garage_buckets | default([]) }}"
+      garage_namespace: "{{ ocp4_workload_garage_namespace }}"

--- a/roles/ocp4_workload_garage/tasks/workload.yml
+++ b/roles/ocp4_workload_garage/tasks/workload.yml
@@ -144,7 +144,7 @@
   kubernetes.core.k8s_info:
     api_version: route.openshift.io/v1
     kind: Route
-    name: garage-web
+    name: garage
     namespace: "{{ ocp4_workload_garage_namespace }}"
   register: r_garage_web_route
   retries: 30

--- a/roles/ocp4_workload_garage/tasks/workload.yml
+++ b/roles/ocp4_workload_garage/tasks/workload.yml
@@ -26,7 +26,6 @@
     template: application.yaml.j2
 
 - name: Wait for Garage Application to sync
-  when: ocp4_workload_garage_wait_for_deployment | bool
   kubernetes.core.k8s_info:
     api_version: argoproj.io/v1alpha1
     kind: Application
@@ -45,7 +44,6 @@
   - r_application.resources[0].status.health.status == 'Healthy'
 
 - name: Wait for Garage StatefulSet to be ready
-  when: ocp4_workload_garage_wait_for_deployment | bool
   kubernetes.core.k8s_info:
     api_version: apps/v1
     kind: StatefulSet
@@ -126,6 +124,13 @@
       pod: "{{ _ocp4_workload_garage_service_name }}-0"
       command: ./garage key create {{ ocp4_workload_garage_key_name }}
     register: r_garage_key
+    retries: 10
+    delay: 5
+    until: r_garage_key is success
+
+  - name: Debug API key creation
+    ansible.builtin.debug:
+      msg: "{{ r_garage_key }}"
 
   - name: Set API key credentials
     ansible.builtin.set_fact:
@@ -155,31 +160,6 @@
     loop: "{{ ocp4_workload_garage_buckets }}"
     loop_control:
       loop_var: bucket_name
-
-- name: Report Garage information to user
-  when: ocp4_workload_garage_enable_user_info_messages | bool
-  block:
-  - name: Set Garage user info messages
-    ansible.builtin.set_fact:
-      _garage_user_info_messages:
-      - msg: "Garage S3 Endpoint (internal): {{ _ocp4_workload_garage_s3_endpoint_internal }}"
-        when: true
-      - msg: "Garage S3 Endpoint (external): {{ _ocp4_workload_garage_s3_endpoint_external }}"
-        when: "{{ _ocp4_workload_garage_s3_endpoint_external | length > 0 }}"
-      - msg: "Garage S3 Access Key: {{ _ocp4_workload_garage_access_key }}"
-        when: "{{ _ocp4_workload_garage_access_key | length > 0 }}"
-      - msg: "Garage S3 Secret Key: {{ _ocp4_workload_garage_secret_key }}"
-        when: "{{ _ocp4_workload_garage_access_key | length > 0 }}"
-      - msg: "Garage Web UI: {{ _ocp4_workload_garage_web_url }}"
-        when: "{{ _ocp4_workload_garage_web_url | length > 0 }}"
-      - msg: "Garage S3 Buckets Created: {{ ocp4_workload_garage_buckets | join(', ') }}"
-        when: "{{ ocp4_workload_garage_buckets | default([]) | length > 0 }}"
-
-  - name: Print Garage information
-    when: item.when | bool
-    agnosticd.core.agnosticd_user_info:
-      msg: "{{ item.msg }}"
-    loop: "{{ _garage_user_info_messages }}"
 
 - name: Save Garage data for user
   when: ocp4_workload_garage_enable_user_info_data | bool

--- a/roles/ocp4_workload_garage/tasks/workload.yml
+++ b/roles/ocp4_workload_garage/tasks/workload.yml
@@ -164,26 +164,40 @@
 - name: Create API key and buckets
   when: ocp4_workload_garage_key_name | length > 0
   block:
+  - name: Check if Garage API key already exists
+    kubernetes.core.k8s_exec:
+      namespace: "{{ ocp4_workload_garage_namespace }}"
+      pod: "{{ _ocp4_workload_garage_service_name }}-0"
+      command: ./garage key info {{ ocp4_workload_garage_key_name }}
+    register: r_garage_key_info
+    failed_when: false
+
   - name: Create Garage API key
+    when: r_garage_key_info.rc != 0
     kubernetes.core.k8s_exec:
       namespace: "{{ ocp4_workload_garage_namespace }}"
       pod: "{{ _ocp4_workload_garage_service_name }}-0"
       command: ./garage key create {{ ocp4_workload_garage_key_name }}
-    register: r_garage_key
+    register: r_garage_key_create
     retries: 10
     delay: 5
-    until: r_garage_key is success
+    until: r_garage_key_create is success
 
-  - name: Debug API key creation
-    ansible.builtin.debug:
-      msg: "{{ r_garage_key }}"
-
-  - name: Set API key credentials
+  - name: Set API key credentials from new key
+    when: r_garage_key_info.rc != 0
     ansible.builtin.set_fact:
       _ocp4_workload_garage_access_key: >-
-        {{ r_garage_key.stdout | regex_search('Key ID: (\S+)', '\1') | first }}
+        {{ r_garage_key_create.stdout | regex_search('Key ID: (\S+)', '\1') | first }}
       _ocp4_workload_garage_secret_key: >-
-        {{ r_garage_key.stdout | regex_search('Secret key: (\S+)', '\1') | first }}
+        {{ r_garage_key_create.stdout | regex_search('Secret key: (\S+)', '\1') | first }}
+
+  - name: Set API key credentials from existing key
+    when: r_garage_key_info.rc == 0
+    ansible.builtin.set_fact:
+      _ocp4_workload_garage_access_key: >-
+        {{ r_garage_key_info.stdout | regex_search('Key ID: (\S+)', '\1') | first }}
+      _ocp4_workload_garage_secret_key: >-
+        {{ r_garage_key_info.stdout | regex_search('Secret key: (\S+)', '\1') | first }}
 
   - name: Save Garage credentials to Secret
     kubernetes.core.k8s:
@@ -205,6 +219,10 @@
       namespace: "{{ ocp4_workload_garage_namespace }}"
       pod: "{{ _ocp4_workload_garage_service_name }}-0"
       command: ./garage bucket create {{ bucket_name }}
+    register: r_bucket_create
+    failed_when:
+    - r_bucket_create.rc != 0
+    - "'already exists' not in r_bucket_create.stderr"
     loop: "{{ ocp4_workload_garage_buckets }}"
     loop_control:
       loop_var: bucket_name
@@ -216,7 +234,7 @@
       pod: "{{ _ocp4_workload_garage_service_name }}-0"
       command: >-
         ./garage bucket allow --read --write
-        {{ bucket_name }} --key {{ ocp4_workload_garage_key_name }}
+        {{ bucket_name }} --key {{ _ocp4_workload_garage_access_key }}
     loop: "{{ ocp4_workload_garage_buckets }}"
     loop_control:
       loop_var: bucket_name

--- a/roles/ocp4_workload_garage/templates/application.yaml.j2
+++ b/roles/ocp4_workload_garage/templates/application.yaml.j2
@@ -29,6 +29,8 @@ spec:
             replication_factor = {{ ocp4_workload_garage_replication_factor }}
             consistency_mode = "{{ ocp4_workload_garage_consistency_mode }}"
             compression_level = 1
+            rpc_bind_addr = "[::]:3901"
+            rpc_secret = "__RPC_SECRET_REPLACE__"
 
             [s3_api]
             s3_region = "{{ ocp4_workload_garage_s3_region }}"
@@ -38,10 +40,6 @@ spec:
             bind_addr = "[::]:3902"
             root_domain = ".web.garage.tld"
             index = "index.html"
-
-            [rpc]
-            bind_addr = "[::]:3901"
-            secret = "__RPC_SECRET_REPLACE__"
 
             [admin]
             api_bind_addr = "[::]:3903"

--- a/roles/ocp4_workload_garage/templates/application.yaml.j2
+++ b/roles/ocp4_workload_garage/templates/application.yaml.j2
@@ -1,0 +1,87 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: {{ ocp4_workload_garage_application_name }}
+  namespace: {{ ocp4_workload_garage_gitops_namespace }}
+  labels:
+    app.kubernetes.io/name: garage
+    app.kubernetes.io/component: application
+spec:
+  project: default
+  source:
+    repoURL: {{ ocp4_workload_garage_chart_repo }}
+    targetRevision: {{ ocp4_workload_garage_chart_revision }}
+    path: {{ ocp4_workload_garage_chart_path }}
+    helm:
+      values: |
+        garage:
+          dbEngine: {{ ocp4_workload_garage_db_engine }}
+          replicationMode: "{{ ocp4_workload_garage_replication_mode }}"
+          s3:
+            api:
+              region: {{ ocp4_workload_garage_s3_region }}
+
+        deployment:
+          replicaCount: {{ ocp4_workload_garage_replicas }}
+
+        persistence:
+          enabled: true
+          meta:
+            size: {{ ocp4_workload_garage_storage_meta_size }}
+{% if ocp4_workload_garage_storage_meta_storage_class | length > 0 %}
+            storageClass: {{ ocp4_workload_garage_storage_meta_storage_class }}
+{% endif %}
+          data:
+            size: {{ ocp4_workload_garage_storage_data_size }}
+{% if ocp4_workload_garage_storage_data_storage_class | length > 0 %}
+            storageClass: {{ ocp4_workload_garage_storage_data_storage_class }}
+{% endif %}
+
+        resources:
+          requests:
+            cpu: {{ ocp4_workload_garage_resources_requests_cpu }}
+            memory: {{ ocp4_workload_garage_resources_requests_memory }}
+          limits:
+            cpu: {{ ocp4_workload_garage_resources_limits_cpu }}
+            memory: {{ ocp4_workload_garage_resources_limits_memory }}
+
+        podSecurityContext:
+          runAsNonRoot: true
+
+        securityContext:
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+
+        ingress:
+          s3:
+            api:
+              enabled: false
+          web:
+            enabled: false
+
+{% if ocp4_workload_garage_helm_values | length > 0 %}
+        {{ ocp4_workload_garage_helm_values | to_nice_yaml(indent=2) | indent(8) }}
+{% endif %}
+
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: {{ ocp4_workload_garage_namespace }}
+
+  syncPolicy:
+{% if ocp4_workload_garage_sync_policy_automated %}
+    automated:
+      prune: {{ ocp4_workload_garage_sync_policy_prune | lower }}
+      selfHeal: {{ ocp4_workload_garage_sync_policy_self_heal | lower }}
+{% endif %}
+    syncOptions:
+    - CreateNamespace=true
+    - RespectIgnoreDifferences=true
+    retry:
+      limit: {{ ocp4_workload_garage_sync_retry_limit }}
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m

--- a/roles/ocp4_workload_garage/templates/application.yaml.j2
+++ b/roles/ocp4_workload_garage/templates/application.yaml.j2
@@ -24,6 +24,12 @@ spec:
 
         deployment:
           replicaCount: {{ ocp4_workload_garage_replicas }}
+          image:
+            repository: {{ ocp4_workload_garage_image_repository }}
+{% if ocp4_workload_garage_image_tag | length > 0 %}
+            tag: "{{ ocp4_workload_garage_image_tag }}"
+{% endif %}
+            pullPolicy: {{ ocp4_workload_garage_image_pull_policy }}
 
         persistence:
           enabled: true
@@ -46,14 +52,13 @@ spec:
             cpu: {{ ocp4_workload_garage_resources_limits_cpu }}
             memory: {{ ocp4_workload_garage_resources_limits_memory }}
 
-        podSecurityContext:
-          runAsNonRoot: true
+        # Clear hardcoded UIDs (1000) to let OpenShift assign from namespace range
+        podSecurityContext: {}
 
         securityContext:
           capabilities:
             drop:
             - ALL
-          readOnlyRootFilesystem: true
 
         ingress:
           s3:

--- a/roles/ocp4_workload_garage/templates/application.yaml.j2
+++ b/roles/ocp4_workload_garage/templates/application.yaml.j2
@@ -7,6 +7,8 @@ metadata:
   labels:
     app.kubernetes.io/name: garage
     app.kubernetes.io/component: application
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
 spec:
   project: default
   source:

--- a/roles/ocp4_workload_garage/templates/application.yaml.j2
+++ b/roles/ocp4_workload_garage/templates/application.yaml.j2
@@ -17,10 +17,36 @@ spec:
       values: |
         garage:
           dbEngine: {{ ocp4_workload_garage_db_engine }}
-          replicationMode: "{{ ocp4_workload_garage_replication_mode }}"
           s3:
             api:
               region: {{ ocp4_workload_garage_s3_region }}
+          garageTomlString: |
+            metadata_dir = "/mnt/meta"
+            data_dir = "/mnt/data"
+            db_engine = "{{ ocp4_workload_garage_db_engine }}"
+            replication_factor = {{ ocp4_workload_garage_replication_factor }}
+            consistency_mode = "{{ ocp4_workload_garage_consistency_mode }}"
+            compression_level = 1
+
+            [s3_api]
+            s3_region = "{{ ocp4_workload_garage_s3_region }}"
+            api_bind_addr = "[::]:3900"
+
+            [s3_web]
+            bind_addr = "[::]:3902"
+            root_domain = ".web.garage.tld"
+            index = "index.html"
+
+            [rpc]
+            bind_addr = "[::]:3901"
+            secret = "__RPC_SECRET_REPLACE__"
+
+            [admin]
+            api_bind_addr = "[::]:3903"
+
+            [kubernetes_discovery]
+            namespace = "{{ ocp4_workload_garage_namespace }}"
+            skip_crd = false
 
         deployment:
           replicaCount: {{ ocp4_workload_garage_replicas }}

--- a/roles/ocp4_workload_garage/templates/application.yaml.j2
+++ b/roles/ocp4_workload_garage/templates/application.yaml.j2
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: garage
     app.kubernetes.io/component: application
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+  - resources-finalizer.argocd.argoproj.io/foreground
 spec:
   project: default
   source:
@@ -48,6 +48,7 @@ spec:
 
             [kubernetes_discovery]
             namespace = "{{ ocp4_workload_garage_namespace }}"
+            service_name = "{{ ocp4_workload_garage_application_name }}-headless"
             skip_crd = false
 
         deployment:

--- a/roles/ocp4_workload_garage/templates/application.yaml.j2
+++ b/roles/ocp4_workload_garage/templates/application.yaml.j2
@@ -52,13 +52,18 @@ spec:
             cpu: {{ ocp4_workload_garage_resources_limits_cpu }}
             memory: {{ ocp4_workload_garage_resources_limits_memory }}
 
-        # Clear hardcoded UIDs (1000) to let OpenShift assign from namespace range
-        podSecurityContext: {}
+        # Null out hardcoded UIDs (1000) so OpenShift assigns from namespace range
+        podSecurityContext:
+          runAsUser: null
+          runAsGroup: null
+          fsGroup: null
+          runAsNonRoot: true
 
         securityContext:
           capabilities:
             drop:
             - ALL
+          readOnlyRootFilesystem: true
 
         ingress:
           s3:

--- a/roles/ocp4_workload_garage/templates/route-s3-api.yaml.j2
+++ b/roles/ocp4_workload_garage/templates/route-s3-api.yaml.j2
@@ -1,0 +1,21 @@
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: garage-s3-api
+  namespace: {{ ocp4_workload_garage_namespace }}
+  labels:
+    app.kubernetes.io/name: garage
+    app.kubernetes.io/component: s3-api
+spec:
+{% if ocp4_workload_garage_s3_api_route_host | length > 0 %}
+  host: {{ ocp4_workload_garage_s3_api_route_host }}
+{% endif %}
+  to:
+    kind: Service
+    name: {{ _ocp4_workload_garage_service_name }}
+  port:
+    targetPort: 3900
+  tls:
+    termination: {{ ocp4_workload_garage_s3_api_route_tls_termination }}
+    insecureEdgeTerminationPolicy: {{ ocp4_workload_garage_s3_api_route_tls_insecure_policy }}

--- a/roles/ocp4_workload_garage/templates/route-s3-api.yaml.j2
+++ b/roles/ocp4_workload_garage/templates/route-s3-api.yaml.j2
@@ -2,7 +2,7 @@
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
-  name: garage-s3-api
+  name: s3
   namespace: {{ ocp4_workload_garage_namespace }}
   labels:
     app.kubernetes.io/name: garage

--- a/roles/ocp4_workload_garage/templates/route-web.yaml.j2
+++ b/roles/ocp4_workload_garage/templates/route-web.yaml.j2
@@ -2,7 +2,7 @@
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
-  name: garage-web
+  name: garage
   namespace: {{ ocp4_workload_garage_namespace }}
   labels:
     app.kubernetes.io/name: garage

--- a/roles/ocp4_workload_garage/templates/route-web.yaml.j2
+++ b/roles/ocp4_workload_garage/templates/route-web.yaml.j2
@@ -1,0 +1,21 @@
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: garage-web
+  namespace: {{ ocp4_workload_garage_namespace }}
+  labels:
+    app.kubernetes.io/name: garage
+    app.kubernetes.io/component: web
+spec:
+{% if ocp4_workload_garage_web_route_host | length > 0 %}
+  host: {{ ocp4_workload_garage_web_route_host }}
+{% endif %}
+  to:
+    kind: Service
+    name: {{ _ocp4_workload_garage_service_name }}
+  port:
+    targetPort: 3902
+  tls:
+    termination: {{ ocp4_workload_garage_web_route_tls_termination }}
+    insecureEdgeTerminationPolicy: {{ ocp4_workload_garage_web_route_tls_insecure_policy }}

--- a/roles/ocp4_workload_quay_operator/defaults/main.yml
+++ b/roles/ocp4_workload_quay_operator/defaults/main.yml
@@ -154,3 +154,23 @@ ocp4_workload_quay_operator_s4_endpoint: "http://s4.{{ ocp4_workload_quay_operat
 
 # S3 region
 ocp4_workload_quay_operator_s4_region: us-east-1
+
+# --------------------------------
+# S3 Storage Configuration (Garage)
+# --------------------------------
+# Set to true to use Garage storage, false to use Noobaa (OCS)
+# Only one of s4_storage_enabled or garage_storage_enabled should be true
+ocp4_workload_quay_operator_garage_storage_enabled: false
+
+# Garage namespace (must match ocp4_workload_garage_namespace)
+ocp4_workload_quay_operator_garage_namespace: garage
+
+# Name of the K8s Secret containing Garage credentials
+# Created automatically by the ocp4_workload_garage role
+ocp4_workload_quay_operator_garage_credentials_secret: garage-s3-credentials
+
+# Bucket name for Quay registry storage
+ocp4_workload_quay_operator_garage_bucket_name: quay-registry
+
+# S3 region (must match Garage's s3_region config)
+ocp4_workload_quay_operator_garage_region: garage

--- a/roles/ocp4_workload_quay_operator/tasks/workload.yml
+++ b/roles/ocp4_workload_quay_operator/tasks/workload.yml
@@ -20,8 +20,52 @@
         S4 storage service not found in namespace {{ ocp4_workload_quay_operator_s4_namespace }}.
         Deploy S4 first using ocp4_workload_s4 role.
 
+  - name: Check Garage service and credentials
+    when: ocp4_workload_quay_operator_garage_storage_enabled | bool
+    block:
+    - name: Check Garage service exists
+      kubernetes.core.k8s_info:
+        api_version: v1
+        kind: Service
+        name: garage
+        namespace: "{{ ocp4_workload_quay_operator_garage_namespace }}"
+      register: r_garage_service
+
+    - name: Assert that Garage service exists
+      ansible.builtin.assert:
+        that:
+        - r_garage_service.resources | length == 1
+        fail_msg: >-
+          Garage storage service not found in namespace {{ ocp4_workload_quay_operator_garage_namespace }}.
+          Deploy Garage first using ocp4_workload_garage role.
+
+    - name: Read Garage credentials Secret
+      kubernetes.core.k8s_info:
+        api_version: v1
+        kind: Secret
+        name: "{{ ocp4_workload_quay_operator_garage_credentials_secret }}"
+        namespace: "{{ ocp4_workload_quay_operator_garage_namespace }}"
+      register: r_garage_credentials
+
+    - name: Assert that Garage credentials Secret exists
+      ansible.builtin.assert:
+        that:
+        - r_garage_credentials.resources | length == 1
+        fail_msg: >-
+          Garage credentials secret '{{ ocp4_workload_quay_operator_garage_credentials_secret }}'
+          not found in namespace {{ ocp4_workload_quay_operator_garage_namespace }}.
+
+    - name: Set Garage credentials from Secret
+      ansible.builtin.set_fact:
+        _ocp4_workload_quay_operator_garage_access_key: >-
+          {{ r_garage_credentials.resources[0].data.access_key | b64decode }}
+        _ocp4_workload_quay_operator_garage_secret_key: >-
+          {{ r_garage_credentials.resources[0].data.secret_key | b64decode }}
+
   - name: Check Noobaa BucketClass exists
-    when: not (ocp4_workload_quay_operator_s4_storage_enabled | bool)
+    when: >-
+      not (ocp4_workload_quay_operator_s4_storage_enabled | bool)
+      and not (ocp4_workload_quay_operator_garage_storage_enabled | bool)
     kubernetes.core.k8s_info:
       api_version: noobaa.io/v1alpha1
       kind: BucketClass
@@ -29,7 +73,9 @@
     register: r_bucket_class
 
   - name: Assert that Noobaa BucketClass exists
-    when: not (ocp4_workload_quay_operator_s4_storage_enabled | bool)
+    when: >-
+      not (ocp4_workload_quay_operator_s4_storage_enabled | bool)
+      and not (ocp4_workload_quay_operator_garage_storage_enabled | bool)
     ansible.builtin.assert:
       that:
       - r_bucket_class.resources | length == 1

--- a/roles/ocp4_workload_quay_operator/templates/config.yaml.j2
+++ b/roles/ocp4_workload_quay_operator/templates/config.yaml.j2
@@ -8,13 +8,12 @@ SUPER_USERS:
 FEATURE_USER_INITIALIZE: true
 {% endif %}
 {% if ocp4_workload_quay_operator_s4_storage_enabled | bool %}
-# S4 Storage Configuration
 DISTRIBUTED_STORAGE_CONFIG:
   s4storage:
     - RadosGWStorage
-    - hostname: s4-api-{{ ocp4_workload_quay_operator_s4_namespace }}.{{ openshift_cluster_ingress_domain }}
-      port: 443
-      is_secure: true
+    - hostname: s4.{{ ocp4_workload_quay_operator_s4_namespace }}.svc.cluster.local
+      port: 7480
+      is_secure: false
       bucket_name: {{ ocp4_workload_quay_operator_s4_bucket_name }}
       storage_path: /datastorage/registry
       access_key: {{ ocp4_workload_quay_operator_s4_access_key }}
@@ -22,4 +21,18 @@ DISTRIBUTED_STORAGE_CONFIG:
 DISTRIBUTED_STORAGE_DEFAULT_LOCATIONS: []
 DISTRIBUTED_STORAGE_PREFERENCE:
 - s4storage
+{% elif ocp4_workload_quay_operator_garage_storage_enabled | bool %}
+DISTRIBUTED_STORAGE_CONFIG:
+  garagestorage:
+    - RadosGWStorage
+    - hostname: garage.{{ ocp4_workload_quay_operator_garage_namespace }}.svc.cluster.local
+      port: 3900
+      is_secure: false
+      bucket_name: {{ ocp4_workload_quay_operator_garage_bucket_name }}
+      storage_path: /datastorage/registry
+      access_key: {{ _ocp4_workload_quay_operator_garage_access_key }}
+      secret_key: {{ _ocp4_workload_quay_operator_garage_secret_key }}
+DISTRIBUTED_STORAGE_DEFAULT_LOCATIONS: []
+DISTRIBUTED_STORAGE_PREFERENCE:
+- garagestorage
 {% endif %}

--- a/roles/ocp4_workload_quay_operator/templates/quay_registry.yaml.j2
+++ b/roles/ocp4_workload_quay_operator/templates/quay_registry.yaml.j2
@@ -10,7 +10,7 @@ spec:
   - kind: postgres
     managed: true
   - kind: objectstorage
-    managed: {{ 'false' if ocp4_workload_quay_operator_s4_storage_enabled | bool else 'true' }}
+    managed: {{ 'false' if (ocp4_workload_quay_operator_s4_storage_enabled | bool or ocp4_workload_quay_operator_garage_storage_enabled | bool) else 'true' }}
   - kind: redis
     managed: true
   - kind: tls


### PR DESCRIPTION
## Summary

- Adds new `ocp4_workload_garage` Ansible role that deploys [Garage](https://garagehq.deuxfleurs.fr/) S3-compatible distributed object storage on OpenShift via ArgoCD
- Installs the Helm chart directly from the [official Garage source repository](https://git.deuxfleurs.fr/Deuxfleurs/garage) (`main-v1` branch) — no local cloning or external Helm repo needed
- Supports configurable replicas, replication mode, storage classes/sizes, resource limits, OpenShift Routes, automatic API key and bucket creation, and a catch-all `ocp4_workload_garage_helm_values` dict for arbitrary Helm chart customization
- Also updates Quay operator role to use Garage instead of s4 or ODF