### PR TITLE
Add ocp4_workload_seaweedfs role for SeaweedFS S3-compatible storage

### DIFF
--- a/roles/ocp4_workload_quay_operator/defaults/main.yml
+++ b/roles/ocp4_workload_quay_operator/defaults/main.yml
@@ -130,15 +130,13 @@ ocp4_workload_quay_operator_registry_startup_probe_failure_threshold: 30
 # --------------------------------
 # Storage Backend Configuration
 # --------------------------------
-# Set to true to use S4 storage, false to use Noobaa (OCS)
-# Default: false (uses Noobaa/OpenShift Container Storage)
-ocp4_workload_quay_operator_s4_storage_enabled: false
+# All false -> use Noobaa/OpenShift Container Storage
+# Only one of s4_storage_enabled, garage_storage_enabled, or seaweedfs_storage_enabled should be true
 
 # --------------------------------
 # S3 Storage Configuration (S4)
 # --------------------------------
-# Only used when ocp4_workload_quay_operator_s4_storage_enabled: true
-# Quay uses S4 storage for object storage backend
+ocp4_workload_quay_operator_s4_storage_enabled: false
 
 # S4 S3 endpoint configuration
 ocp4_workload_quay_operator_s4_namespace: s4
@@ -159,7 +157,7 @@ ocp4_workload_quay_operator_s4_region: us-east-1
 # S3 Storage Configuration (Garage)
 # ---------------------------------
 # Set to true to use Garage storage, false to use Noobaa (OCS)
-# Only one of s4_storage_enabled or garage_storage_enabled should be true
+# Only one of s4_storage_enabled, garage_storage_enabled, or seaweedfs_storage_enabled should be true
 ocp4_workload_quay_operator_garage_storage_enabled: false
 
 # Garage namespace (must match ocp4_workload_garage_namespace)

--- a/roles/ocp4_workload_quay_operator/defaults/main.yml
+++ b/roles/ocp4_workload_quay_operator/defaults/main.yml
@@ -155,9 +155,9 @@ ocp4_workload_quay_operator_s4_endpoint: "http://s4.{{ ocp4_workload_quay_operat
 # S3 region
 ocp4_workload_quay_operator_s4_region: us-east-1
 
-# --------------------------------
+# ---------------------------------
 # S3 Storage Configuration (Garage)
-# --------------------------------
+# ---------------------------------
 # Set to true to use Garage storage, false to use Noobaa (OCS)
 # Only one of s4_storage_enabled or garage_storage_enabled should be true
 ocp4_workload_quay_operator_garage_storage_enabled: false
@@ -175,9 +175,9 @@ ocp4_workload_quay_operator_garage_bucket_name: quay-registry
 # S3 region (must match Garage's s3_region config)
 ocp4_workload_quay_operator_garage_region: us-east-1
 
-# --------------------------------
+# ------------------------------------
 # S3 Storage Configuration (SeaweedFS)
-# --------------------------------
+# ------------------------------------
 # Set to true to use SeaweedFS storage
 # Only one of s4_storage_enabled, garage_storage_enabled, or seaweedfs_storage_enabled should be true
 ocp4_workload_quay_operator_seaweedfs_storage_enabled: false

--- a/roles/ocp4_workload_quay_operator/defaults/main.yml
+++ b/roles/ocp4_workload_quay_operator/defaults/main.yml
@@ -174,3 +174,23 @@ ocp4_workload_quay_operator_garage_bucket_name: quay-registry
 
 # S3 region (must match Garage's s3_region config)
 ocp4_workload_quay_operator_garage_region: us-east-1
+
+# --------------------------------
+# S3 Storage Configuration (SeaweedFS)
+# --------------------------------
+# Set to true to use SeaweedFS storage
+# Only one of s4_storage_enabled, garage_storage_enabled, or seaweedfs_storage_enabled should be true
+ocp4_workload_quay_operator_seaweedfs_storage_enabled: false
+
+# SeaweedFS namespace (must match ocp4_workload_seaweedfs_namespace)
+ocp4_workload_quay_operator_seaweedfs_namespace: seaweedfs
+
+# Name of the K8s Secret containing SeaweedFS credentials
+# Created automatically by the ocp4_workload_seaweedfs role
+ocp4_workload_quay_operator_seaweedfs_credentials_secret: seaweedfs-s3-credentials
+
+# Bucket name for Quay registry storage
+ocp4_workload_quay_operator_seaweedfs_bucket_name: quay-registry
+
+# S3 region (must match SeaweedFS config)
+ocp4_workload_quay_operator_seaweedfs_region: us-east-1

--- a/roles/ocp4_workload_quay_operator/tasks/workload.yml
+++ b/roles/ocp4_workload_quay_operator/tasks/workload.yml
@@ -62,10 +62,53 @@
         _ocp4_workload_quay_operator_garage_secret_key: >-
           {{ r_garage_credentials.resources[0].data.secret_key | b64decode }}
 
+  - name: Check SeaweedFS service and credentials
+    when: ocp4_workload_quay_operator_seaweedfs_storage_enabled | bool
+    block:
+    - name: Check SeaweedFS S3 service exists
+      kubernetes.core.k8s_info:
+        api_version: v1
+        kind: Service
+        name: "{{ ocp4_workload_quay_operator_seaweedfs_namespace }}-s3"
+        namespace: "{{ ocp4_workload_quay_operator_seaweedfs_namespace }}"
+      register: r_seaweedfs_service
+
+    - name: Assert that SeaweedFS S3 service exists
+      ansible.builtin.assert:
+        that:
+        - r_seaweedfs_service.resources | length == 1
+        fail_msg: >-
+          SeaweedFS S3 service not found in namespace {{ ocp4_workload_quay_operator_seaweedfs_namespace }}.
+          Deploy SeaweedFS first using ocp4_workload_seaweedfs role.
+
+    - name: Read SeaweedFS credentials Secret
+      kubernetes.core.k8s_info:
+        api_version: v1
+        kind: Secret
+        name: "{{ ocp4_workload_quay_operator_seaweedfs_credentials_secret }}"
+        namespace: "{{ ocp4_workload_quay_operator_seaweedfs_namespace }}"
+      register: r_seaweedfs_credentials
+
+    - name: Assert that SeaweedFS credentials Secret exists
+      ansible.builtin.assert:
+        that:
+        - r_seaweedfs_credentials.resources | length == 1
+        fail_msg: >-
+          SeaweedFS credentials secret '{{ ocp4_workload_quay_operator_seaweedfs_credentials_secret }}'
+          not found in namespace {{ ocp4_workload_quay_operator_seaweedfs_namespace }}.
+
+    - name: Set SeaweedFS credentials from Secret
+      ansible.builtin.set_fact:
+        _ocp4_workload_quay_operator_seaweedfs_access_key: >-
+          {{ r_seaweedfs_credentials.resources[0].data.access_key | b64decode }}
+        _ocp4_workload_quay_operator_seaweedfs_secret_key: >-
+          {{ r_seaweedfs_credentials.resources[0].data.secret_key | b64decode }}
+
   - name: Check Noobaa BucketClass exists
     when: >-
       not (ocp4_workload_quay_operator_s4_storage_enabled | bool)
       and not (ocp4_workload_quay_operator_garage_storage_enabled | bool)
+      and not (ocp4_workload_quay_operator_seaweedfs_storage_enabled | bool)
     kubernetes.core.k8s_info:
       api_version: noobaa.io/v1alpha1
       kind: BucketClass
@@ -76,6 +119,7 @@
     when: >-
       not (ocp4_workload_quay_operator_s4_storage_enabled | bool)
       and not (ocp4_workload_quay_operator_garage_storage_enabled | bool)
+      and not (ocp4_workload_quay_operator_seaweedfs_storage_enabled | bool)
     ansible.builtin.assert:
       that:
       - r_bucket_class.resources | length == 1

--- a/roles/ocp4_workload_quay_operator/templates/config.yaml.j2
+++ b/roles/ocp4_workload_quay_operator/templates/config.yaml.j2
@@ -50,3 +50,17 @@ DISTRIBUTED_STORAGE_DEFAULT_LOCATIONS: []
 DISTRIBUTED_STORAGE_PREFERENCE:
 - seaweedfsstorage
 {% endif %}
+FEATURE_SECURITY_SCANNER: true
+SECURITY_SCANNER_V4_ENDPOINT: http://quay-clair-app:80
+CLAIR_CONFIG:
+  updater:
+    interval: 1h
+  matcher:
+    max_conn_pool: 100
+  indexer:
+    conn_pool: 100
+  httpclient:
+    timeout: 30s
+    transport:
+      idle_conn_timeout: 60s
+      max_idle_conns: 100

--- a/roles/ocp4_workload_quay_operator/templates/config.yaml.j2
+++ b/roles/ocp4_workload_quay_operator/templates/config.yaml.j2
@@ -50,17 +50,3 @@ DISTRIBUTED_STORAGE_DEFAULT_LOCATIONS: []
 DISTRIBUTED_STORAGE_PREFERENCE:
 - seaweedfsstorage
 {% endif %}
-FEATURE_SECURITY_SCANNER: true
-SECURITY_SCANNER_V4_ENDPOINT: http://quay-clair-app:80
-CLAIR_CONFIG:
-  updater:
-    interval: 1h
-  matcher:
-    max_conn_pool: 100
-  indexer:
-    conn_pool: 100
-  httpclient:
-    timeout: 30s
-    transport:
-      idle_conn_timeout: 60s
-      max_idle_conns: 100

--- a/roles/ocp4_workload_quay_operator/templates/config.yaml.j2
+++ b/roles/ocp4_workload_quay_operator/templates/config.yaml.j2
@@ -35,4 +35,18 @@ DISTRIBUTED_STORAGE_CONFIG:
 DISTRIBUTED_STORAGE_DEFAULT_LOCATIONS: []
 DISTRIBUTED_STORAGE_PREFERENCE:
 - garagestorage
+{% elif ocp4_workload_quay_operator_seaweedfs_storage_enabled | bool %}
+DISTRIBUTED_STORAGE_CONFIG:
+  seaweedfsstorage:
+    - RadosGWStorage
+    - hostname: {{ ocp4_workload_quay_operator_seaweedfs_namespace }}-s3.{{ ocp4_workload_quay_operator_seaweedfs_namespace }}.svc.cluster.local
+      port: 8333
+      is_secure: false
+      bucket_name: {{ ocp4_workload_quay_operator_seaweedfs_bucket_name }}
+      storage_path: /datastorage/registry
+      access_key: {{ _ocp4_workload_quay_operator_seaweedfs_access_key }}
+      secret_key: {{ _ocp4_workload_quay_operator_seaweedfs_secret_key }}
+DISTRIBUTED_STORAGE_DEFAULT_LOCATIONS: []
+DISTRIBUTED_STORAGE_PREFERENCE:
+- seaweedfsstorage
 {% endif %}

--- a/roles/ocp4_workload_quay_operator/templates/quay_registry.yaml.j2
+++ b/roles/ocp4_workload_quay_operator/templates/quay_registry.yaml.j2
@@ -10,7 +10,7 @@ spec:
   - kind: postgres
     managed: true
   - kind: objectstorage
-    managed: {{ 'false' if (ocp4_workload_quay_operator_s4_storage_enabled | bool or ocp4_workload_quay_operator_garage_storage_enabled | bool) else 'true' }}
+    managed: {{ 'false' if (ocp4_workload_quay_operator_s4_storage_enabled | bool or ocp4_workload_quay_operator_garage_storage_enabled | bool or ocp4_workload_quay_operator_seaweedfs_storage_enabled | bool) else 'true' }}
   - kind: redis
     managed: true
   - kind: tls

--- a/roles/ocp4_workload_seaweedfs/defaults/main.yml
+++ b/roles/ocp4_workload_seaweedfs/defaults/main.yml
@@ -1,0 +1,97 @@
+---
+# SeaweedFS (S3-compatible distributed object storage) workload configuration
+
+# Namespace
+ocp4_workload_seaweedfs_namespace: seaweedfs
+
+# ArgoCD Application configuration
+ocp4_workload_seaweedfs_application_name: seaweedfs
+ocp4_workload_seaweedfs_gitops_namespace: openshift-gitops
+
+# Helm chart source (git repo, matches garage role pattern)
+ocp4_workload_seaweedfs_chart_repo: https://github.com/seaweedfs/seaweedfs
+# Pin to a release tag for production deployments
+ocp4_workload_seaweedfs_chart_revision: master
+ocp4_workload_seaweedfs_chart_path: k8s/charts/seaweedfs
+
+# Image configuration
+# Default image: chrislusf/seaweedfs (official Docker Hub image)
+ocp4_workload_seaweedfs_image_name: chrislusf/seaweedfs
+# Empty tag defaults to chart's appVersion
+ocp4_workload_seaweedfs_image_tag: ""
+ocp4_workload_seaweedfs_image_pull_policy: IfNotPresent
+
+# Component replicas
+# Master: manages cluster topology and volume assignments
+ocp4_workload_seaweedfs_master_replicas: 1
+# Volume: stores actual file data
+ocp4_workload_seaweedfs_volume_replicas: 1
+# Filer: provides file system abstraction and S3 gateway
+ocp4_workload_seaweedfs_filer_replicas: 1
+
+# Replication strategy (3-digit code: datacenter, rack, node copies)
+# "000" = no replication (single-node testing)
+# "001" = replicate once on a different volume on the same node
+# "010" = replicate once on a different rack
+# "100" = replicate once on a different datacenter
+ocp4_workload_seaweedfs_replication: "000"
+
+# S3 region
+ocp4_workload_seaweedfs_s3_region: us-east-1
+
+# Storage - master metadata
+ocp4_workload_seaweedfs_storage_master_size: 1Gi
+ocp4_workload_seaweedfs_storage_master_storage_class: ""
+
+# Storage - volume server data (main object data)
+ocp4_workload_seaweedfs_storage_volume_size: 10Gi
+ocp4_workload_seaweedfs_storage_volume_storage_class: ""
+
+# Storage - filer metadata
+ocp4_workload_seaweedfs_storage_filer_size: 1Gi
+ocp4_workload_seaweedfs_storage_filer_storage_class: ""
+
+# Resource requests and limits (applied to all components)
+ocp4_workload_seaweedfs_resources_requests_cpu: 100m
+ocp4_workload_seaweedfs_resources_requests_memory: 256Mi
+ocp4_workload_seaweedfs_resources_limits_cpu: 1000m
+ocp4_workload_seaweedfs_resources_limits_memory: 1Gi
+
+# S3 API Route (port 8333)
+ocp4_workload_seaweedfs_s3_api_route_enabled: true
+ocp4_workload_seaweedfs_s3_api_route_host: ""
+ocp4_workload_seaweedfs_s3_api_route_tls_termination: edge
+ocp4_workload_seaweedfs_s3_api_route_tls_insecure_policy: Redirect
+
+# S3 authentication
+# When enabled, creates a config Secret with access credentials
+# that the SeaweedFS S3 gateway uses for IAM
+ocp4_workload_seaweedfs_s3_auth_enabled: true
+
+# S3 credentials - leave empty to auto-generate
+ocp4_workload_seaweedfs_access_key: ""
+ocp4_workload_seaweedfs_secret_key: ""
+ocp4_workload_seaweedfs_access_key_length: 20
+ocp4_workload_seaweedfs_secret_key_length: 40
+
+# Name of the S3 config Secret (SeaweedFS IAM config, consumed by Helm chart)
+ocp4_workload_seaweedfs_s3_config_secret: seaweedfs-s3-config
+
+# Post-deploy: credentials Secret and buckets
+# This Secret stores access_key/secret_key in the same format as the garage role
+# for consumption by other roles (e.g. quay_operator)
+ocp4_workload_seaweedfs_credentials_secret: seaweedfs-s3-credentials
+ocp4_workload_seaweedfs_buckets: []
+
+# Catch-all for arbitrary Helm values (merged last, can override anything)
+ocp4_workload_seaweedfs_helm_values: {}
+
+# ArgoCD sync configuration
+ocp4_workload_seaweedfs_sync_policy_automated: true
+ocp4_workload_seaweedfs_sync_policy_self_heal: true
+ocp4_workload_seaweedfs_sync_policy_prune: true
+ocp4_workload_seaweedfs_sync_retry_limit: 5
+
+# User info configuration
+ocp4_workload_seaweedfs_enable_user_info_messages: true
+ocp4_workload_seaweedfs_enable_user_info_data: true

--- a/roles/ocp4_workload_seaweedfs/defaults/main.yml
+++ b/roles/ocp4_workload_seaweedfs/defaults/main.yml
@@ -21,7 +21,7 @@ ocp4_workload_seaweedfs_image_name: chrislusf/seaweedfs
 ocp4_workload_seaweedfs_image_tag: ""
 ocp4_workload_seaweedfs_image_pull_policy: IfNotPresent
 
-# Component replicas
+# Component replicas (only odd numbers allowed)
 # Master: manages cluster topology and volume assignments
 ocp4_workload_seaweedfs_master_replicas: 1
 # Volume: stores actual file data

--- a/roles/ocp4_workload_seaweedfs/defaults/main.yml
+++ b/roles/ocp4_workload_seaweedfs/defaults/main.yml
@@ -64,18 +64,18 @@ ocp4_workload_seaweedfs_s3_api_route_tls_termination: edge
 ocp4_workload_seaweedfs_s3_api_route_tls_insecure_policy: Redirect
 
 # S3 authentication
-# When enabled, creates a config Secret with access credentials
-# that the SeaweedFS S3 gateway uses for IAM
+# When enabled, credentials are configured dynamically via weed shell
+# after the filer pods are ready (avoids SeaweedFS static config bug)
 ocp4_workload_seaweedfs_s3_auth_enabled: true
+
+# S3 IAM user name for dynamic credential creation
+ocp4_workload_seaweedfs_s3_user: s3admin
 
 # S3 credentials - leave empty to auto-generate
 ocp4_workload_seaweedfs_access_key: ""
 ocp4_workload_seaweedfs_secret_key: ""
 ocp4_workload_seaweedfs_access_key_length: 20
 ocp4_workload_seaweedfs_secret_key_length: 40
-
-# Name of the S3 config Secret (SeaweedFS IAM config, consumed by Helm chart)
-ocp4_workload_seaweedfs_s3_config_secret: seaweedfs-s3-config
 
 # Post-deploy: credentials Secret and buckets
 # This Secret stores access_key/secret_key in the same format as the garage role

--- a/roles/ocp4_workload_seaweedfs/defaults/main.yml
+++ b/roles/ocp4_workload_seaweedfs/defaults/main.yml
@@ -93,5 +93,4 @@ ocp4_workload_seaweedfs_sync_policy_prune: true
 ocp4_workload_seaweedfs_sync_retry_limit: 5
 
 # User info configuration
-ocp4_workload_seaweedfs_enable_user_info_messages: true
 ocp4_workload_seaweedfs_enable_user_info_data: true

--- a/roles/ocp4_workload_seaweedfs/meta/main.yml
+++ b/roles/ocp4_workload_seaweedfs/meta/main.yml
@@ -1,0 +1,18 @@
+---
+galaxy_info:
+  role_name: ocp4_workload_seaweedfs
+  author: Red Hat GPTE
+  description: >-
+    Deploy SeaweedFS S3-compatible distributed object storage on OpenShift using GitOps.
+  license: MIT
+  min_ansible_version: "2.9"
+  platforms: []
+  galaxy_tags:
+  - ocp
+  - openshift
+  - s3
+  - storage
+  - gitops
+  - argocd
+  - seaweedfs
+dependencies: []

--- a/roles/ocp4_workload_seaweedfs/tasks/main.yml
+++ b/roles/ocp4_workload_seaweedfs/tasks/main.yml
@@ -1,0 +1,10 @@
+---
+- name: Running workload tasks
+  when: ACTION == "provision"
+  ansible.builtin.include_tasks:
+    file: workload.yml
+
+- name: Running destroy tasks
+  when: ACTION == "destroy"
+  ansible.builtin.include_tasks:
+    file: remove_workload.yml

--- a/roles/ocp4_workload_seaweedfs/tasks/remove_workload.yml
+++ b/roles/ocp4_workload_seaweedfs/tasks/remove_workload.yml
@@ -1,0 +1,44 @@
+---
+- name: Delete S3 API Route
+  kubernetes.core.k8s:
+    state: absent
+    api_version: route.openshift.io/v1
+    kind: Route
+    name: s3
+    namespace: "{{ ocp4_workload_seaweedfs_namespace }}"
+
+- name: Delete ArgoCD Application
+  kubernetes.core.k8s:
+    state: absent
+    api_version: argoproj.io/v1alpha1
+    kind: Application
+    name: "{{ ocp4_workload_seaweedfs_application_name }}"
+    namespace: "{{ ocp4_workload_seaweedfs_gitops_namespace }}"
+
+- name: Wait for Application deletion
+  kubernetes.core.k8s_info:
+    api_version: argoproj.io/v1alpha1
+    kind: Application
+    name: "{{ ocp4_workload_seaweedfs_application_name }}"
+    namespace: "{{ ocp4_workload_seaweedfs_gitops_namespace }}"
+  register: r_application
+  retries: 30
+  delay: 10
+  until: r_application.resources | length == 0
+
+- name: Delete SeaweedFS namespace
+  kubernetes.core.k8s:
+    state: absent
+    api_version: v1
+    kind: Namespace
+    name: "{{ ocp4_workload_seaweedfs_namespace }}"
+
+- name: Wait for namespace deletion
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: Namespace
+    name: "{{ ocp4_workload_seaweedfs_namespace }}"
+  register: r_namespace
+  retries: 60
+  delay: 5
+  until: r_namespace.resources | length == 0

--- a/roles/ocp4_workload_seaweedfs/tasks/workload.yml
+++ b/roles/ocp4_workload_seaweedfs/tasks/workload.yml
@@ -13,7 +13,7 @@
     when: ocp4_workload_seaweedfs_access_key | default('') | length == 0
     ansible.builtin.set_fact:
       _ocp4_workload_seaweedfs_access_key: >-
-        {{ lookup('password', '/dev/null length={{ ocp4_workload_seaweedfs_access_key_length }} chars=ascii_letters,digits') }}
+        {{ lookup('password', '/dev/null length=' ~ ocp4_workload_seaweedfs_access_key_length ~ ' chars=ascii_letters,digits') }}
 
   - name: Use provided S3 access key
     when: ocp4_workload_seaweedfs_access_key | default('') | length > 0
@@ -24,7 +24,7 @@
     when: ocp4_workload_seaweedfs_secret_key | default('') | length == 0
     ansible.builtin.set_fact:
       _ocp4_workload_seaweedfs_secret_key: >-
-        {{ lookup('password', '/dev/null length={{ ocp4_workload_seaweedfs_secret_key_length }} chars=ascii_letters,digits') }}
+        {{ lookup('password', '/dev/null length=' ~ ocp4_workload_seaweedfs_secret_key_length ~ ' chars=ascii_letters,digits') }}
 
   - name: Use provided S3 secret key
     when: ocp4_workload_seaweedfs_secret_key | default('') | length > 0

--- a/roles/ocp4_workload_seaweedfs/tasks/workload.yml
+++ b/roles/ocp4_workload_seaweedfs/tasks/workload.yml
@@ -1,0 +1,228 @@
+---
+- name: Set internal variables
+  ansible.builtin.set_fact:
+    _ocp4_workload_seaweedfs_s3_endpoint_internal: >-
+      http://{{ ocp4_workload_seaweedfs_application_name }}-s3.{{ ocp4_workload_seaweedfs_namespace }}.svc.cluster.local:8333
+    _ocp4_workload_seaweedfs_s3_endpoint_external: ""
+    _ocp4_workload_seaweedfs_access_key: ""
+    _ocp4_workload_seaweedfs_secret_key: ""
+
+- name: Generate S3 credentials
+  block:
+  - name: Generate S3 access key
+    when: ocp4_workload_seaweedfs_access_key | default('') | length == 0
+    ansible.builtin.set_fact:
+      _ocp4_workload_seaweedfs_access_key: >-
+        {{ lookup('password', '/dev/null length={{ ocp4_workload_seaweedfs_access_key_length }} chars=ascii_letters,digits') }}
+
+  - name: Use provided S3 access key
+    when: ocp4_workload_seaweedfs_access_key | default('') | length > 0
+    ansible.builtin.set_fact:
+      _ocp4_workload_seaweedfs_access_key: "{{ ocp4_workload_seaweedfs_access_key }}"
+
+  - name: Generate S3 secret key
+    when: ocp4_workload_seaweedfs_secret_key | default('') | length == 0
+    ansible.builtin.set_fact:
+      _ocp4_workload_seaweedfs_secret_key: >-
+        {{ lookup('password', '/dev/null length={{ ocp4_workload_seaweedfs_secret_key_length }} chars=ascii_letters,digits') }}
+
+  - name: Use provided S3 secret key
+    when: ocp4_workload_seaweedfs_secret_key | default('') | length > 0
+    ansible.builtin.set_fact:
+      _ocp4_workload_seaweedfs_secret_key: "{{ ocp4_workload_seaweedfs_secret_key }}"
+
+- name: Create SeaweedFS namespace
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: "{{ ocp4_workload_seaweedfs_namespace }}"
+        labels:
+          argocd.argoproj.io/managed-by: "{{ ocp4_workload_seaweedfs_gitops_namespace }}"
+
+- name: Create SeaweedFS S3 config Secret
+  when: ocp4_workload_seaweedfs_s3_auth_enabled | bool
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: "{{ ocp4_workload_seaweedfs_s3_config_secret }}"
+        namespace: "{{ ocp4_workload_seaweedfs_namespace }}"
+      type: Opaque
+      stringData:
+        seaweedfs_s3_config: |
+          {
+            "identities": [
+              {
+                "name": "admin",
+                "credentials": [
+                  {
+                    "accessKey": "{{ _ocp4_workload_seaweedfs_access_key }}",
+                    "secretKey": "{{ _ocp4_workload_seaweedfs_secret_key }}"
+                  }
+                ],
+                "actions": ["Admin", "Read", "Write", "List", "Tagging"]
+              }
+            ]
+          }
+
+- name: Create ArgoCD Application for SeaweedFS
+  kubernetes.core.k8s:
+    state: present
+    template: application.yaml.j2
+
+- name: Wait for SeaweedFS Application to sync
+  kubernetes.core.k8s_info:
+    api_version: argoproj.io/v1alpha1
+    kind: Application
+    name: "{{ ocp4_workload_seaweedfs_application_name }}"
+    namespace: "{{ ocp4_workload_seaweedfs_gitops_namespace }}"
+  register: r_application
+  retries: 60
+  delay: 10
+  until:
+  - r_application.resources is defined
+  - r_application.resources | length > 0
+  - r_application.resources[0].status is defined
+  - r_application.resources[0].status.sync is defined
+  - r_application.resources[0].status.sync.status == 'Synced'
+  - r_application.resources[0].status.health is defined
+  - r_application.resources[0].status.health.status == 'Healthy'
+
+- name: Wait for SeaweedFS Master StatefulSet to be ready
+  kubernetes.core.k8s_info:
+    api_version: apps/v1
+    kind: StatefulSet
+    name: "{{ ocp4_workload_seaweedfs_application_name }}-master"
+    namespace: "{{ ocp4_workload_seaweedfs_namespace }}"
+  register: r_seaweedfs_master
+  retries: 60
+  delay: 10
+  until:
+  - r_seaweedfs_master.resources is defined
+  - r_seaweedfs_master.resources | length > 0
+  - r_seaweedfs_master.resources[0].status is defined
+  - r_seaweedfs_master.resources[0].status.readyReplicas is defined
+  - r_seaweedfs_master.resources[0].status.readyReplicas | int == ocp4_workload_seaweedfs_master_replicas | int
+
+- name: Wait for SeaweedFS Volume StatefulSet to be ready
+  kubernetes.core.k8s_info:
+    api_version: apps/v1
+    kind: StatefulSet
+    name: "{{ ocp4_workload_seaweedfs_application_name }}-volume"
+    namespace: "{{ ocp4_workload_seaweedfs_namespace }}"
+  register: r_seaweedfs_volume
+  retries: 60
+  delay: 10
+  until:
+  - r_seaweedfs_volume.resources is defined
+  - r_seaweedfs_volume.resources | length > 0
+  - r_seaweedfs_volume.resources[0].status is defined
+  - r_seaweedfs_volume.resources[0].status.readyReplicas is defined
+  - r_seaweedfs_volume.resources[0].status.readyReplicas | int == ocp4_workload_seaweedfs_volume_replicas | int
+
+- name: Wait for SeaweedFS Filer StatefulSet to be ready
+  kubernetes.core.k8s_info:
+    api_version: apps/v1
+    kind: StatefulSet
+    name: "{{ ocp4_workload_seaweedfs_application_name }}-filer"
+    namespace: "{{ ocp4_workload_seaweedfs_namespace }}"
+  register: r_seaweedfs_filer
+  retries: 60
+  delay: 10
+  until:
+  - r_seaweedfs_filer.resources is defined
+  - r_seaweedfs_filer.resources | length > 0
+  - r_seaweedfs_filer.resources[0].status is defined
+  - r_seaweedfs_filer.resources[0].status.readyReplicas is defined
+  - r_seaweedfs_filer.resources[0].status.readyReplicas | int == ocp4_workload_seaweedfs_filer_replicas | int
+
+- name: Create S3 API Route
+  when: ocp4_workload_seaweedfs_s3_api_route_enabled | bool
+  kubernetes.core.k8s:
+    state: present
+    template: route-s3-api.yaml.j2
+
+- name: Get S3 API Route
+  when: ocp4_workload_seaweedfs_s3_api_route_enabled | bool
+  kubernetes.core.k8s_info:
+    api_version: route.openshift.io/v1
+    kind: Route
+    name: s3
+    namespace: "{{ ocp4_workload_seaweedfs_namespace }}"
+  register: r_seaweedfs_s3_route
+  retries: 30
+  delay: 5
+  until:
+  - r_seaweedfs_s3_route.resources is defined
+  - r_seaweedfs_s3_route.resources | length > 0
+  - r_seaweedfs_s3_route.resources[0].spec.host is defined
+
+- name: Set S3 API endpoint URL
+  when:
+  - ocp4_workload_seaweedfs_s3_api_route_enabled | bool
+  - r_seaweedfs_s3_route.resources | length > 0
+  ansible.builtin.set_fact:
+    _ocp4_workload_seaweedfs_s3_endpoint_external: "https://{{ r_seaweedfs_s3_route.resources[0].spec.host }}"
+
+- name: Create buckets
+  when: ocp4_workload_seaweedfs_buckets | default([]) | length > 0
+  block:
+  - name: Create SeaweedFS buckets
+    kubernetes.core.k8s_exec:
+      namespace: "{{ ocp4_workload_seaweedfs_namespace }}"
+      pod: "{{ ocp4_workload_seaweedfs_application_name }}-filer-0"
+      command: >-
+        /usr/bin/weed shell
+        -master {{ ocp4_workload_seaweedfs_application_name }}-master:9333
+        -filer {{ ocp4_workload_seaweedfs_application_name }}-filer:8888
+        -shell.command 's3.bucket.create -name {{ bucket_name }}'
+    register: r_bucket_create
+    failed_when:
+    - r_bucket_create.rc != 0
+    - "'already exists' not in (r_bucket_create.stderr | default(''))"
+    retries: 10
+    delay: 5
+    until: r_bucket_create is success or 'already exists' in (r_bucket_create.stderr | default(''))
+    loop: "{{ ocp4_workload_seaweedfs_buckets }}"
+    loop_control:
+      loop_var: bucket_name
+
+- name: Save SeaweedFS credentials to Secret
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: "{{ ocp4_workload_seaweedfs_credentials_secret }}"
+        namespace: "{{ ocp4_workload_seaweedfs_namespace }}"
+      type: Opaque
+      stringData:
+        access_key: "{{ _ocp4_workload_seaweedfs_access_key }}"
+        secret_key: "{{ _ocp4_workload_seaweedfs_secret_key }}"
+
+- name: Save SeaweedFS information for user
+  when: ocp4_workload_seaweedfs_enable_user_info_messages | bool
+  agnosticd.core.agnosticd_user_info:
+    msg: |-
+      SeaweedFS S3-compatible storage deployed in namespace {{ ocp4_workload_seaweedfs_namespace }}.
+      Internal S3 endpoint: {{ _ocp4_workload_seaweedfs_s3_endpoint_internal }}
+      {% if _ocp4_workload_seaweedfs_s3_endpoint_external | length > 0 %}
+      External S3 endpoint: {{ _ocp4_workload_seaweedfs_s3_endpoint_external }}
+      {% endif %}
+
+- name: Save SeaweedFS data for user
+  when: ocp4_workload_seaweedfs_enable_user_info_data | bool
+  agnosticd.core.agnosticd_user_info:
+    data:
+      seaweedfs_s3_access_key_id: "{{ _ocp4_workload_seaweedfs_access_key }}"
+      seaweedfs_s3_secret_access_key: "{{ _ocp4_workload_seaweedfs_secret_key }}"
+      seaweedfs_s3_endpoint_internal: "{{ _ocp4_workload_seaweedfs_s3_endpoint_internal }}"
+      seaweedfs_s3_endpoint_external: "{{ _ocp4_workload_seaweedfs_s3_endpoint_external }}"
+      seaweedfs_buckets: "{{ ocp4_workload_seaweedfs_buckets | default([]) }}"
+      seaweedfs_namespace: "{{ ocp4_workload_seaweedfs_namespace }}"

--- a/roles/ocp4_workload_seaweedfs/tasks/workload.yml
+++ b/roles/ocp4_workload_seaweedfs/tasks/workload.yml
@@ -42,34 +42,6 @@
         labels:
           argocd.argoproj.io/managed-by: "{{ ocp4_workload_seaweedfs_gitops_namespace }}"
 
-- name: Create SeaweedFS S3 config Secret
-  when: ocp4_workload_seaweedfs_s3_auth_enabled | bool
-  kubernetes.core.k8s:
-    state: present
-    definition:
-      apiVersion: v1
-      kind: Secret
-      metadata:
-        name: "{{ ocp4_workload_seaweedfs_s3_config_secret }}"
-        namespace: "{{ ocp4_workload_seaweedfs_namespace }}"
-      type: Opaque
-      stringData:
-        seaweedfs_s3_config: |
-          {
-            "identities": [
-              {
-                "name": "admin",
-                "credentials": [
-                  {
-                    "accessKey": "{{ _ocp4_workload_seaweedfs_access_key }}",
-                    "secretKey": "{{ _ocp4_workload_seaweedfs_secret_key }}"
-                  }
-                ],
-                "actions": ["Admin", "Read", "Write", "List", "Tagging"]
-              }
-            ]
-          }
-
 - name: Create ArgoCD Application for SeaweedFS
   kubernetes.core.k8s:
     state: present
@@ -140,6 +112,26 @@
   - r_seaweedfs_filer.resources[0].status is defined
   - r_seaweedfs_filer.resources[0].status.readyReplicas is defined
   - r_seaweedfs_filer.resources[0].status.readyReplicas | int == ocp4_workload_seaweedfs_filer_replicas | int
+
+- name: Configure S3 credentials dynamically
+  when: ocp4_workload_seaweedfs_s3_auth_enabled | bool
+  kubernetes.core.k8s_exec:
+    namespace: "{{ ocp4_workload_seaweedfs_namespace }}"
+    pod: "{{ ocp4_workload_seaweedfs_application_name }}-filer-0"
+    command: >-
+      sh -c 'echo "s3.configure
+      -access_key {{ _ocp4_workload_seaweedfs_access_key }}
+      -secret_key {{ _ocp4_workload_seaweedfs_secret_key }}
+      -user {{ ocp4_workload_seaweedfs_s3_user }}
+      -actions Admin,Read,Write,List,Tagging
+      -apply" |
+      /usr/bin/weed shell
+      -master {{ ocp4_workload_seaweedfs_application_name }}-master:9333
+      -filer {{ ocp4_workload_seaweedfs_application_name }}-filer:8888'
+  register: r_s3_configure
+  retries: 10
+  delay: 5
+  until: r_s3_configure is not failed
 
 - name: Create S3 API Route
   when: ocp4_workload_seaweedfs_s3_api_route_enabled | bool

--- a/roles/ocp4_workload_seaweedfs/tasks/workload.yml
+++ b/roles/ocp4_workload_seaweedfs/tasks/workload.yml
@@ -177,17 +177,17 @@
       namespace: "{{ ocp4_workload_seaweedfs_namespace }}"
       pod: "{{ ocp4_workload_seaweedfs_application_name }}-filer-0"
       command: >-
+        sh -c 'echo "s3.bucket.create -name {{ bucket_name }}" |
         /usr/bin/weed shell
         -master {{ ocp4_workload_seaweedfs_application_name }}-master:9333
-        -filer {{ ocp4_workload_seaweedfs_application_name }}-filer:8888
-        -shell.command 's3.bucket.create -name {{ bucket_name }}'
+        -filer {{ ocp4_workload_seaweedfs_application_name }}-filer:8888'
     register: r_bucket_create
     failed_when:
     - r_bucket_create.rc != 0
-    - "'already exists' not in (r_bucket_create.stderr | default(''))"
+    - "'already exists' not in (r_bucket_create.stdout | default('') ~ r_bucket_create.stderr | default(''))"
     retries: 10
     delay: 5
-    until: r_bucket_create is success or 'already exists' in (r_bucket_create.stderr | default(''))
+    until: r_bucket_create is not failed
     loop: "{{ ocp4_workload_seaweedfs_buckets }}"
     loop_control:
       loop_var: bucket_name

--- a/roles/ocp4_workload_seaweedfs/tasks/workload.yml
+++ b/roles/ocp4_workload_seaweedfs/tasks/workload.yml
@@ -206,16 +206,6 @@
         access_key: "{{ _ocp4_workload_seaweedfs_access_key }}"
         secret_key: "{{ _ocp4_workload_seaweedfs_secret_key }}"
 
-- name: Save SeaweedFS information for user
-  when: ocp4_workload_seaweedfs_enable_user_info_messages | bool
-  agnosticd.core.agnosticd_user_info:
-    msg: |-
-      SeaweedFS S3-compatible storage deployed in namespace {{ ocp4_workload_seaweedfs_namespace }}.
-      Internal S3 endpoint: {{ _ocp4_workload_seaweedfs_s3_endpoint_internal }}
-      {% if _ocp4_workload_seaweedfs_s3_endpoint_external | length > 0 %}
-      External S3 endpoint: {{ _ocp4_workload_seaweedfs_s3_endpoint_external }}
-      {% endif %}
-
 - name: Save SeaweedFS data for user
   when: ocp4_workload_seaweedfs_enable_user_info_data | bool
   agnosticd.core.agnosticd_user_info:

--- a/roles/ocp4_workload_seaweedfs/templates/application.yaml.j2
+++ b/roles/ocp4_workload_seaweedfs/templates/application.yaml.j2
@@ -1,0 +1,135 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: {{ ocp4_workload_seaweedfs_application_name }}
+  namespace: {{ ocp4_workload_seaweedfs_gitops_namespace }}
+  labels:
+    app.kubernetes.io/name: seaweedfs
+    app.kubernetes.io/component: application
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io/foreground
+spec:
+  project: default
+  source:
+    repoURL: {{ ocp4_workload_seaweedfs_chart_repo }}
+    targetRevision: {{ ocp4_workload_seaweedfs_chart_revision }}
+    path: {{ ocp4_workload_seaweedfs_chart_path }}
+    helm:
+      values: |
+        global:
+          seaweedfs:
+            image:
+              name: {{ ocp4_workload_seaweedfs_image_name }}
+          imagePullPolicy: {{ ocp4_workload_seaweedfs_image_pull_policy }}
+
+        master:
+          replicas: {{ ocp4_workload_seaweedfs_master_replicas }}
+          defaultReplication: "{{ ocp4_workload_seaweedfs_replication }}"
+          data:
+            type: persistentVolumeClaim
+            size: {{ ocp4_workload_seaweedfs_storage_master_size }}
+{% if ocp4_workload_seaweedfs_storage_master_storage_class | length > 0 %}
+            storageClass: {{ ocp4_workload_seaweedfs_storage_master_storage_class }}
+{% endif %}
+          logs:
+            type: persistentVolumeClaim
+            size: {{ ocp4_workload_seaweedfs_storage_master_size }}
+{% if ocp4_workload_seaweedfs_storage_master_storage_class | length > 0 %}
+            storageClass: {{ ocp4_workload_seaweedfs_storage_master_storage_class }}
+{% endif %}
+          resources:
+            requests:
+              cpu: {{ ocp4_workload_seaweedfs_resources_requests_cpu }}
+              memory: {{ ocp4_workload_seaweedfs_resources_requests_memory }}
+            limits:
+              cpu: {{ ocp4_workload_seaweedfs_resources_limits_cpu }}
+              memory: {{ ocp4_workload_seaweedfs_resources_limits_memory }}
+
+        volume:
+          replicas: {{ ocp4_workload_seaweedfs_volume_replicas }}
+          dataDirs:
+          - name: data1
+            type: persistentVolumeClaim
+            size: {{ ocp4_workload_seaweedfs_storage_volume_size }}
+{% if ocp4_workload_seaweedfs_storage_volume_storage_class | length > 0 %}
+            storageClass: {{ ocp4_workload_seaweedfs_storage_volume_storage_class }}
+{% endif %}
+            maxVolumes: 0
+          idx:
+            type: persistentVolumeClaim
+            size: {{ ocp4_workload_seaweedfs_storage_master_size }}
+{% if ocp4_workload_seaweedfs_storage_volume_storage_class | length > 0 %}
+            storageClass: {{ ocp4_workload_seaweedfs_storage_volume_storage_class }}
+{% endif %}
+          logs:
+            type: persistentVolumeClaim
+            size: {{ ocp4_workload_seaweedfs_storage_master_size }}
+{% if ocp4_workload_seaweedfs_storage_volume_storage_class | length > 0 %}
+            storageClass: {{ ocp4_workload_seaweedfs_storage_volume_storage_class }}
+{% endif %}
+          resources:
+            requests:
+              cpu: {{ ocp4_workload_seaweedfs_resources_requests_cpu }}
+              memory: {{ ocp4_workload_seaweedfs_resources_requests_memory }}
+            limits:
+              cpu: {{ ocp4_workload_seaweedfs_resources_limits_cpu }}
+              memory: {{ ocp4_workload_seaweedfs_resources_limits_memory }}
+
+        filer:
+          replicas: {{ ocp4_workload_seaweedfs_filer_replicas }}
+          s3:
+            enabled: true
+            port: 8333
+{% if ocp4_workload_seaweedfs_s3_auth_enabled | bool %}
+            enableAuth: true
+            existingConfigSecret: {{ ocp4_workload_seaweedfs_s3_config_secret }}
+{% else %}
+            enableAuth: false
+{% endif %}
+          data:
+            type: persistentVolumeClaim
+            size: {{ ocp4_workload_seaweedfs_storage_filer_size }}
+{% if ocp4_workload_seaweedfs_storage_filer_storage_class | length > 0 %}
+            storageClass: {{ ocp4_workload_seaweedfs_storage_filer_storage_class }}
+{% endif %}
+          logs:
+            type: persistentVolumeClaim
+            size: {{ ocp4_workload_seaweedfs_storage_filer_size }}
+{% if ocp4_workload_seaweedfs_storage_filer_storage_class | length > 0 %}
+            storageClass: {{ ocp4_workload_seaweedfs_storage_filer_storage_class }}
+{% endif %}
+          resources:
+            requests:
+              cpu: {{ ocp4_workload_seaweedfs_resources_requests_cpu }}
+              memory: {{ ocp4_workload_seaweedfs_resources_requests_memory }}
+            limits:
+              cpu: {{ ocp4_workload_seaweedfs_resources_limits_cpu }}
+              memory: {{ ocp4_workload_seaweedfs_resources_limits_memory }}
+
+        s3:
+          enabled: false
+
+{% if ocp4_workload_seaweedfs_helm_values | length > 0 %}
+        {{ ocp4_workload_seaweedfs_helm_values | to_nice_yaml(indent=2) | indent(8) }}
+{% endif %}
+
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: {{ ocp4_workload_seaweedfs_namespace }}
+
+  syncPolicy:
+{% if ocp4_workload_seaweedfs_sync_policy_automated %}
+    automated:
+      prune: {{ ocp4_workload_seaweedfs_sync_policy_prune | lower }}
+      selfHeal: {{ ocp4_workload_seaweedfs_sync_policy_self_heal | lower }}
+{% endif %}
+    syncOptions:
+    - CreateNamespace=true
+    - RespectIgnoreDifferences=true
+    retry:
+      limit: {{ ocp4_workload_seaweedfs_sync_retry_limit }}
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m

--- a/roles/ocp4_workload_seaweedfs/templates/application.yaml.j2
+++ b/roles/ocp4_workload_seaweedfs/templates/application.yaml.j2
@@ -81,12 +81,7 @@ spec:
           s3:
             enabled: true
             port: 8333
-{% if ocp4_workload_seaweedfs_s3_auth_enabled | bool %}
-            enableAuth: true
-            existingConfigSecret: {{ ocp4_workload_seaweedfs_s3_config_secret }}
-{% else %}
-            enableAuth: false
-{% endif %}
+            enableAuth: {{ ocp4_workload_seaweedfs_s3_auth_enabled | bool | lower }}
           data:
             type: persistentVolumeClaim
             size: {{ ocp4_workload_seaweedfs_storage_filer_size }}

--- a/roles/ocp4_workload_seaweedfs/templates/route-s3-api.yaml.j2
+++ b/roles/ocp4_workload_seaweedfs/templates/route-s3-api.yaml.j2
@@ -1,0 +1,21 @@
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: s3
+  namespace: {{ ocp4_workload_seaweedfs_namespace }}
+  labels:
+    app.kubernetes.io/name: seaweedfs
+    app.kubernetes.io/component: s3-api
+spec:
+{% if ocp4_workload_seaweedfs_s3_api_route_host | length > 0 %}
+  host: {{ ocp4_workload_seaweedfs_s3_api_route_host }}
+{% endif %}
+  to:
+    kind: Service
+    name: {{ ocp4_workload_seaweedfs_application_name }}-s3
+  port:
+    targetPort: 8333
+  tls:
+    termination: {{ ocp4_workload_seaweedfs_s3_api_route_tls_termination }}
+    insecureEdgeTerminationPolicy: {{ ocp4_workload_seaweedfs_s3_api_route_tls_insecure_policy }}


### PR DESCRIPTION
## Summary

- Add new `ocp4_workload_seaweedfs` role that deploys SeaweedFS S3-compatible distributed object storage on OpenShift via ArgoCD/Helm
- Integrate SeaweedFS as a fourth storage backend option in `ocp4_workload_quay_operator` (alongside Noobaa, Garage, and S4)
- SeaweedFS addresses Garage's limitation where Clair vulnerability scanning fails to fetch image layers from Garage's S3 API

## Details

**New role (`ocp4_workload_seaweedfs`):**
- Deploys master, volume, and filer components via ArgoCD Application using the official SeaweedFS Helm chart
- Pre-configures S3 IAM credentials via a config Secret before deployment
- Creates buckets via `weed shell` exec into filer pod
- Stores S3 credentials in a K8s Secret (`seaweedfs-s3-credentials`) for consumption by downstream roles
- Creates OpenShift Route for external S3 API access (port 8333)
- Reports endpoints and credentials via `agnosticd_user_info`

**Quay operator updates:**
- Added `ocp4_workload_quay_operator_seaweedfs_*` configuration variables
- Added SeaweedFS service/credential validation block in workload tasks
- Added `RadosGWStorage` config block in Quay's `DISTRIBUTED_STORAGE_CONFIG`
- Updated `objectstorage` managed condition in QuayRegistry CR