### PR TITLE
[ocp4_workload_rhacs] Add specific DNS for central route

### DIFF
--- a/roles/ocp4_workload_rhacs/tasks/certificate.yml
+++ b/roles/ocp4_workload_rhacs/tasks/certificate.yml
@@ -5,7 +5,7 @@
     kind: ClusterIssuer
     name: acme-bifrost-production-ddns
   register: r_clusterissuer
-      
+
 - name: Create specific CNAME record for central
   when: r_clusterissuer.resources | default([]) | length > 0
   block:

--- a/roles/ocp4_workload_rhacs/tasks/certificate.yml
+++ b/roles/ocp4_workload_rhacs/tasks/certificate.yml
@@ -30,7 +30,6 @@
         tsig_secret: "{{ r_tsig_secret.resources[0].data[tsig_secret_ref_key] | b64decode }}"
       
     - name: Create specific CNAME record for central
-      when: cluster_dns_server is defined
       community.general.nsupdate:
         server: >-
           {{ ddns_server

--- a/roles/ocp4_workload_rhacs/tasks/certificate.yml
+++ b/roles/ocp4_workload_rhacs/tasks/certificate.yml
@@ -33,7 +33,7 @@
     community.general.nsupdate:
       server: "{{ lookup('community.general.dig', ddns_server) }}"
       zone: "{{ ddns_zone }}"
-      record: "central-{{ ocp4_workload_rhacs_central_namespace }}.{{ openshift_cluster_inress_domain | replace('.' + ddns_zone, '') }}"
+      record: "central-{{ ocp4_workload_rhacs_central_namespace }}.{{ openshift_cluster_ingress_domain | replace('.' + ddns_zone, '') }}"
       type: CNAME
       ttl: 30
       port: "{{ cluster_dns_port | d('53') }}"

--- a/roles/ocp4_workload_rhacs/tasks/certificate.yml
+++ b/roles/ocp4_workload_rhacs/tasks/certificate.yml
@@ -1,4 +1,51 @@
 ---
+- name: Create specific CNAME record for central
+  when: cluster_dns_server is defined
+  block:
+    - name: Get ClusterIssuer info
+      kubernetes.core.k8s_info:
+        api_version: cert-manager.io/v1
+        kind: ClusterIssuer
+        name: acme-bifrost-production-ddns
+      register: r_clusterissuer
+    - name: Set facts from ClusterIssuer
+      vars:
+        _webhook: "{{ r_clusterissuer.resources[0].spec.acme.solvers[0].dns01.webhook.config }}"
+      set_fact:
+        ddns_server: "{{ _webhook.ddnsServer }}"
+        ddns_zone: "{{ _webhook.ddnsZone }}"
+        tsig_key_name: "{{ _webhook.tsigKeyName }}"
+        tsig_secret_ref_name: "{{ _webhook.tsigSecretRef.name }}"
+        tsig_secret_ref_key: "{{ _webhook.tsigSecretRef.key }}"
+    - name: Get TSIG secret value
+      kubernetes.core.k8s_info:
+        api_version: v1
+        kind: Secret
+        name: "{{ tsig_secret_ref_name }}"
+        namespace: cert-manager
+      register: r_tsig_secret
+    - name: Set TSIG secret fact
+      set_fact:
+        tsig_secret: "{{ r_tsig_secret.resources[0].data[tsig_secret_ref_key] | b64decode }}"
+      
+    - name: Create specific CNAME record for central
+      when: cluster_dns_server is defined
+      community.general.nsupdate:
+        server: >-
+          {{ ddns_server
+          | ansible.utils.ipaddr
+          | ternary(cluster_dns_server, lookup('community.general.dig', ddns_server))
+          }}
+        zone: "{{ ddns_zone }}"
+        record: "central-{{ ocp4_workload_rhacs_central_namespace }}.{{ openshift_cluster_ingress_domain }}"
+        type: CNAME
+        ttl: 30
+        port: "{{ cluster_dns_port | d('53') }}"
+        value: "console-openshift-console.{{ openshift_cluster_ingress_domain }}
+        key_name: "{{ tsig_key_name }}"
+        key_secret: "{{ tsig_secret }}"
+        key_algorithm: "hmac-sha256"
+  
 # Check for existing valid certificate and skip provisioning if found
 - name: Check if valid Certificate already exists
   kubernetes.core.k8s_info:

--- a/roles/ocp4_workload_rhacs/tasks/certificate.yml
+++ b/roles/ocp4_workload_rhacs/tasks/certificate.yml
@@ -31,11 +31,7 @@
       
     - name: Create specific CNAME record for central
       community.general.nsupdate:
-        server: >-
-          {{ ddns_server
-          | ansible.utils.ipaddr
-          | ternary(cluster_dns_server, lookup('community.general.dig', ddns_server))
-          }}
+        server: "{{ lookup('community.general.dig', ddns_server) }}"
         zone: "{{ ddns_zone }}"
         record: "central-{{ ocp4_workload_rhacs_central_namespace }}.{{ openshift_cluster_ingress_domain }}"
         type: CNAME

--- a/roles/ocp4_workload_rhacs/tasks/certificate.yml
+++ b/roles/ocp4_workload_rhacs/tasks/certificate.yml
@@ -33,7 +33,7 @@
     community.general.nsupdate:
       server: "{{ lookup('community.general.dig', ddns_server) }}"
       zone: "{{ ddns_zone }}"
-      record: "central-{{ ocp4_workload_rhacs_central_namespace }}.{{ openshift_cluster_inress_domain | ansible.builtin.replace('.' + ddns_zone, '') }}"
+      record: "central-{{ ocp4_workload_rhacs_central_namespace }}.{{ openshift_cluster_inress_domain | replace('.' + ddns_zone, '') }}"
       type: CNAME
       ttl: 30
       port: "{{ cluster_dns_port | d('53') }}"

--- a/roles/ocp4_workload_rhacs/tasks/certificate.yml
+++ b/roles/ocp4_workload_rhacs/tasks/certificate.yml
@@ -1,13 +1,14 @@
 ---
+- name: Get ClusterIssuer info
+  kubernetes.core.k8s_info:
+    api_version: cert-manager.io/v1
+    kind: ClusterIssuer
+    name: acme-bifrost-production-ddns
+  register: r_clusterissuer
+      
 - name: Create specific CNAME record for central
-  when: cluster_dns_server is defined
+  when: r_clusterissuer.resources | default([]) | length > 0
   block:
-    - name: Get ClusterIssuer info
-      kubernetes.core.k8s_info:
-        api_version: cert-manager.io/v1
-        kind: ClusterIssuer
-        name: acme-bifrost-production-ddns
-      register: r_clusterissuer
     - name: Set facts from ClusterIssuer
       vars:
         _webhook: "{{ r_clusterissuer.resources[0].spec.acme.solvers[0].dns01.webhook.config }}"

--- a/roles/ocp4_workload_rhacs/tasks/certificate.yml
+++ b/roles/ocp4_workload_rhacs/tasks/certificate.yml
@@ -33,7 +33,7 @@
       community.general.nsupdate:
         server: "{{ lookup('community.general.dig', ddns_server) }}"
         zone: "{{ ddns_zone }}"
-        record: "central-{{ ocp4_workload_rhacs_central_namespace }}"
+        record: "central-{{ ocp4_workload_rhacs_central_namespace }}.apps.cluster-{{ guid }}"
         type: CNAME
         ttl: 30
         port: "{{ cluster_dns_port | d('53') }}"

--- a/roles/ocp4_workload_rhacs/tasks/certificate.yml
+++ b/roles/ocp4_workload_rhacs/tasks/certificate.yml
@@ -41,7 +41,7 @@
         type: CNAME
         ttl: 30
         port: "{{ cluster_dns_port | d('53') }}"
-        value: "console-openshift-console.{{ openshift_cluster_ingress_domain }}
+        value: "console-openshift-console.{{ openshift_cluster_ingress_domain }}"
         key_name: "{{ tsig_key_name }}"
         key_secret: "{{ tsig_secret }}"
         key_algorithm: "hmac-sha256"

--- a/roles/ocp4_workload_rhacs/tasks/certificate.yml
+++ b/roles/ocp4_workload_rhacs/tasks/certificate.yml
@@ -33,7 +33,7 @@
       community.general.nsupdate:
         server: "{{ lookup('community.general.dig', ddns_server) }}"
         zone: "{{ ddns_zone }}"
-        record: "central-{{ ocp4_workload_rhacs_central_namespace }}.{{ openshift_cluster_ingress_domain }}"
+        record: "central-{{ ocp4_workload_rhacs_central_namespace }}"
         type: CNAME
         ttl: 30
         port: "{{ cluster_dns_port | d('53') }}"

--- a/roles/ocp4_workload_rhacs/tasks/certificate.yml
+++ b/roles/ocp4_workload_rhacs/tasks/certificate.yml
@@ -33,7 +33,7 @@
     community.general.nsupdate:
       server: "{{ lookup('community.general.dig', ddns_server) }}"
       zone: "{{ ddns_zone }}"
-      record: "central-{{ ocp4_workload_rhacs_central_namespace }}.apps.cluster-{{ guid }}"
+      record: "central-{{ ocp4_workload_rhacs_central_namespace }}.{{ openshift_cluster_inress_domain | ansible.builtin.replace('.' + ddns_zone, '') }}"
       type: CNAME
       ttl: 30
       port: "{{ cluster_dns_port | d('53') }}"

--- a/roles/ocp4_workload_rhacs/tasks/certificate.yml
+++ b/roles/ocp4_workload_rhacs/tasks/certificate.yml
@@ -37,7 +37,7 @@
         type: CNAME
         ttl: 30
         port: "{{ cluster_dns_port | d('53') }}"
-        value: "console-openshift-console.{{ openshift_cluster_ingress_domain }}"
+        value: "console-openshift-console.{{ openshift_cluster_ingress_domain }}."
         key_name: "{{ tsig_key_name }}"
         key_secret: "{{ tsig_secret }}"
         key_algorithm: "hmac-sha256"

--- a/roles/ocp4_workload_rhacs/tasks/certificate.yml
+++ b/roles/ocp4_workload_rhacs/tasks/certificate.yml
@@ -12,7 +12,7 @@
   - name: Set facts from ClusterIssuer
     vars:
       _webhook: "{{ r_clusterissuer.resources[0].spec.acme.solvers[0].dns01.webhook.config }}"
-    set_fact:
+    ansible.builtin.set_fact:
       ddns_server: "{{ _webhook.ddnsServer }}"
       ddns_zone: "{{ _webhook.ddnsZone }}"
       tsig_key_name: "{{ _webhook.tsigKeyName }}"
@@ -26,7 +26,7 @@
       namespace: cert-manager
     register: r_tsig_secret
   - name: Set TSIG secret fact
-    set_fact:
+    ansible.builtin.set_fact:
       tsig_secret: "{{ r_tsig_secret.resources[0].data[tsig_secret_ref_key] | b64decode }}"
 
   - name: Create specific CNAME record for central

--- a/roles/ocp4_workload_rhacs/tasks/certificate.yml
+++ b/roles/ocp4_workload_rhacs/tasks/certificate.yml
@@ -9,39 +9,39 @@
 - name: Create specific CNAME record for central
   when: r_clusterissuer.resources | default([]) | length > 0
   block:
-    - name: Set facts from ClusterIssuer
-      vars:
-        _webhook: "{{ r_clusterissuer.resources[0].spec.acme.solvers[0].dns01.webhook.config }}"
-      set_fact:
-        ddns_server: "{{ _webhook.ddnsServer }}"
-        ddns_zone: "{{ _webhook.ddnsZone }}"
-        tsig_key_name: "{{ _webhook.tsigKeyName }}"
-        tsig_secret_ref_name: "{{ _webhook.tsigSecretRef.name }}"
-        tsig_secret_ref_key: "{{ _webhook.tsigSecretRef.key }}"
-    - name: Get TSIG secret value
-      kubernetes.core.k8s_info:
-        api_version: v1
-        kind: Secret
-        name: "{{ tsig_secret_ref_name }}"
-        namespace: cert-manager
-      register: r_tsig_secret
-    - name: Set TSIG secret fact
-      set_fact:
-        tsig_secret: "{{ r_tsig_secret.resources[0].data[tsig_secret_ref_key] | b64decode }}"
-      
-    - name: Create specific CNAME record for central
-      community.general.nsupdate:
-        server: "{{ lookup('community.general.dig', ddns_server) }}"
-        zone: "{{ ddns_zone }}"
-        record: "central-{{ ocp4_workload_rhacs_central_namespace }}.apps.cluster-{{ guid }}"
-        type: CNAME
-        ttl: 30
-        port: "{{ cluster_dns_port | d('53') }}"
-        value: "console-openshift-console.{{ openshift_cluster_ingress_domain }}."
-        key_name: "{{ tsig_key_name }}"
-        key_secret: "{{ tsig_secret }}"
-        key_algorithm: "hmac-sha256"
-  
+  - name: Set facts from ClusterIssuer
+    vars:
+      _webhook: "{{ r_clusterissuer.resources[0].spec.acme.solvers[0].dns01.webhook.config }}"
+    set_fact:
+      ddns_server: "{{ _webhook.ddnsServer }}"
+      ddns_zone: "{{ _webhook.ddnsZone }}"
+      tsig_key_name: "{{ _webhook.tsigKeyName }}"
+      tsig_secret_ref_name: "{{ _webhook.tsigSecretRef.name }}"
+      tsig_secret_ref_key: "{{ _webhook.tsigSecretRef.key }}"
+  - name: Get TSIG secret value
+    kubernetes.core.k8s_info:
+      api_version: v1
+      kind: Secret
+      name: "{{ tsig_secret_ref_name }}"
+      namespace: cert-manager
+    register: r_tsig_secret
+  - name: Set TSIG secret fact
+    set_fact:
+      tsig_secret: "{{ r_tsig_secret.resources[0].data[tsig_secret_ref_key] | b64decode }}"
+
+  - name: Create specific CNAME record for central
+    community.general.nsupdate:
+      server: "{{ lookup('community.general.dig', ddns_server) }}"
+      zone: "{{ ddns_zone }}"
+      record: "central-{{ ocp4_workload_rhacs_central_namespace }}.apps.cluster-{{ guid }}"
+      type: CNAME
+      ttl: 30
+      port: "{{ cluster_dns_port | d('53') }}"
+      value: "console-openshift-console.{{ openshift_cluster_ingress_domain }}."
+      key_name: "{{ tsig_key_name }}"
+      key_secret: "{{ tsig_secret }}"
+      key_algorithm: "hmac-sha256"
+
 # Check for existing valid certificate and skip provisioning if found
 - name: Check if valid Certificate already exists
   kubernetes.core.k8s_info:


### PR DESCRIPTION
**1. The "Wildcard Match" Rule**
In the DNS world (RFC 1034), a wildcard record (e.g., *.[apps.mydomain.com](http://apps.mydomain.com/)) only matches if the name requested does not exist in the zone.
If you have:
*.[apps.mydomain.com](http://apps.mydomain.com/)  A  1.2.3.4
When you query [test.apps.mydomain.com](http://test.apps.mydomain.com/), the server looks for a specific match. Since one doesn't exist, it falls back to the wildcard. Success.

**2. The Problem: Empty Non-Terminals**
When you create _[acme-challenge.test.apps.mydomain.com](http://acme-challenge.test.apps.mydomain.com/), you have technically created a branch in the DNS tree. Even if [test.apps.mydomain.com](http://test.apps.mydomain.com/) has no IP address (A record) of its own, it now "exists" as a parent of the ACME record.
Before: [test.apps.mydomain.com](http://test.apps.mydomain.com/) did not exist. The wildcard covered it.
After: [test.apps.mydomain.com](http://test.apps.mydomain.com/) now exists as an Empty Non-Terminal. Because it "exists" (to lead to the ACME record), the DNS server stops looking at the wildcard. Since test itself has no A record, the server returns NODATA (NOERROR with 0 answers).