### PR TITLE
Add reencrypt route support to RHACS role

### DIFF
--- a/roles/ocp4_workload_rhacs/defaults/main.yml
+++ b/roles/ocp4_workload_rhacs/defaults/main.yml
@@ -25,6 +25,10 @@ ocp4_workload_rhacs_enable_vm_scanning: false
 # If no certificate is issued successfully, the role will deploy Central without a proper certificate
 ocp4_workload_rhacs_enable_route_certs: true
 
+# Enable reencrypt route for Central
+# Requires rhacs-central-tls secret to exist in stackrox namespace
+ocp4_workload_rhacs_enable_reencrypt_route: false
+
 # Enable collector config for rhacs 4.8+
 ocp4_workload_rhacs_collector_config_enable: false
 ocp4_workload_rhacs_collector_config_expternal_ips_enable: true

--- a/roles/ocp4_workload_rhacs/tasks/workload.yml
+++ b/roles/ocp4_workload_rhacs/tasks/workload.yml
@@ -257,10 +257,10 @@
   agnosticd.core.agnosticd_user_info:
     msg: "{{ item }}"
   loop:
-  - ""
-  - "Your RHACS console is available at: {{ _ocp4_workload_rhacs_central_route }}"
-  - "RHACS portal username: admin"
-  - "RHACS portal password: {{ _ocp4_workload_rhacs_central_admin_password }}"
+    - ""
+    - "Your RHACS console is available at: {{ _ocp4_workload_rhacs_central_route }}"
+    - "RHACS portal username: admin"
+    - "RHACS portal password: {{ _ocp4_workload_rhacs_central_admin_password }}"
 
 - name: Save user data
   agnosticd.core.agnosticd_user_info:

--- a/roles/ocp4_workload_rhacs/tasks/workload.yml
+++ b/roles/ocp4_workload_rhacs/tasks/workload.yml
@@ -137,6 +137,25 @@
     _ocp4_workload_rhacs_central_host: "{{ r_stackrox_central_route.resources[0].spec.host }}"
     _ocp4_workload_rhacs_central_route: "https://{{ r_stackrox_central_route.resources[0].spec.host }}"
 
+- name: Get Central reencrypt route
+  when: ocp4_workload_rhacs_enable_reencrypt_route | bool
+  block:
+    - name: Get reencrypt route info
+      kubernetes.core.k8s_info:
+        kind: Route
+        api_version: route.openshift.io/v1
+        namespace: "{{ ocp4_workload_rhacs_central_namespace }}"
+        name: central-reencrypt
+      register: r_stackrox_central_reencrypt_route
+      retries: 5
+      delay: 5
+      until: r_stackrox_central_reencrypt_route.resources[0].spec.host is defined
+
+    - name: Store Central reencrypt Route facts
+      ansible.builtin.set_fact:
+        _ocp4_workload_rhacs_central_reencrypt_host: "{{ r_stackrox_central_reencrypt_route.resources[0].spec.host }}"
+        _ocp4_workload_rhacs_central_reencrypt_route: "https://{{ r_stackrox_central_reencrypt_route.resources[0].spec.host }}"
+
 - name: Register DNS for Central route
   when: ocp4_workload_rhacs_enable_dns_registration | bool
   ansible.builtin.include_tasks: dns_registration.yml
@@ -256,15 +275,19 @@
 - name: Print user info
   agnosticd.core.agnosticd_user_info:
     msg: "{{ item }}"
-  loop:
-    - ""
-    - "Your RHACS console is available at: {{ _ocp4_workload_rhacs_central_route }}"
-    - "RHACS portal username: admin"
-    - "RHACS portal password: {{ _ocp4_workload_rhacs_central_admin_password }}"
+  loop: >-
+    {{ ['', 'Your RHACS console is available at: ' + _ocp4_workload_rhacs_central_route]
+    + (['RHACS reencrypt route is available at: ' + _ocp4_workload_rhacs_central_reencrypt_route]
+       if ocp4_workload_rhacs_enable_reencrypt_route | bool and _ocp4_workload_rhacs_central_reencrypt_route is defined
+       else [])
+    + ['RHACS portal username: admin', 'RHACS portal password: ' + _ocp4_workload_rhacs_central_admin_password] }}
 
 - name: Save user data
   agnosticd.core.agnosticd_user_info:
-    data:
-      acs_route: "{{ _ocp4_workload_rhacs_central_route }}"
-      acs_portal_username: admin
-      acs_portal_password: "{{ _ocp4_workload_rhacs_central_admin_password }}"
+    data: >-
+      {{ {'acs_route': _ocp4_workload_rhacs_central_route,
+          'acs_portal_username': 'admin',
+          'acs_portal_password': _ocp4_workload_rhacs_central_admin_password}
+      | combine({'acs_reencrypt_route': _ocp4_workload_rhacs_central_reencrypt_route}
+                if ocp4_workload_rhacs_enable_reencrypt_route | bool and _ocp4_workload_rhacs_central_reencrypt_route is defined
+                else {}) }}

--- a/roles/ocp4_workload_rhacs/tasks/workload.yml
+++ b/roles/ocp4_workload_rhacs/tasks/workload.yml
@@ -83,10 +83,10 @@
 
     - name: Extract and process certificate chain
       ansible.builtin.set_fact:
-        ocp4_workload_rhacs_reencrypt_destination_ca: >-
+        ocp4_workload_rhacs_reencrypt_destination_ca: |-
           {{ r_rhacs_central_tls_secret.resources[0].data['tls.crt']
              | b64decode
-             | regex_replace('^.*?-----END CERTIFICATE-----\n', '', multiline=True) }}
+             | regex_replace('^.*?-----END CERTIFICATE-----\n', '') }}
 
 - name: Create Central
   vars:

--- a/roles/ocp4_workload_rhacs/tasks/workload.yml
+++ b/roles/ocp4_workload_rhacs/tasks/workload.yml
@@ -95,7 +95,8 @@
 
     - name: Combine intermediate CAs with cluster trust bundle
       ansible.builtin.set_fact:
-        ocp4_workload_rhacs_reencrypt_destination_ca: "{{ _cert_intermediate_ca_chain }}{{ r_cluster_trusted_ca_bundle.resources[0].data['ca-bundle.crt'] }}"
+        ocp4_workload_rhacs_reencrypt_destination_ca: >-
+          {{ _cert_intermediate_ca_chain }}{{ r_cluster_trusted_ca_bundle.resources[0].data['ca-bundle.crt'] }}
 
 - name: Create Central
   vars:

--- a/roles/ocp4_workload_rhacs/tasks/workload.yml
+++ b/roles/ocp4_workload_rhacs/tasks/workload.yml
@@ -69,6 +69,25 @@
   when: ocp4_workload_rhacs_enable_route_certs | bool
   ansible.builtin.include_tasks: certificate.yml
 
+- name: Extract CA certificate chain for reencrypt route
+  when: ocp4_workload_rhacs_enable_reencrypt_route | bool
+  block:
+    - name: Get rhacs-central-tls secret
+      kubernetes.core.k8s_info:
+        api_version: v1
+        kind: Secret
+        name: rhacs-central-tls
+        namespace: "{{ ocp4_workload_rhacs_central_namespace }}"
+      register: r_rhacs_central_tls_secret
+      failed_when: r_rhacs_central_tls_secret.resources | length == 0
+
+    - name: Extract and process certificate chain
+      ansible.builtin.set_fact:
+        ocp4_workload_rhacs_reencrypt_destination_ca: >-
+          {{ r_rhacs_central_tls_secret.resources[0].data['tls.crt']
+             | b64decode
+             | regex_replace('^.*?-----END CERTIFICATE-----\n', '', multiline=True) }}
+
 - name: Create Central
   vars:
     _ocp4_workload_rhacs_central_certificate: "{{ r_certificate_central is defined and r_certificate_central is succeeded }}"

--- a/roles/ocp4_workload_rhacs/tasks/workload.yml
+++ b/roles/ocp4_workload_rhacs/tasks/workload.yml
@@ -81,9 +81,21 @@
       register: r_rhacs_central_tls_secret
       failed_when: r_rhacs_central_tls_secret.resources | length == 0
 
-    - name: Extract and process certificate chain
+    - name: Extract intermediate CA chain from certificate
       ansible.builtin.set_fact:
-        ocp4_workload_rhacs_reencrypt_destination_ca: "{{ r_rhacs_central_tls_secret.resources[0].data['tls.crt'] | b64decode | regex_replace('^[\\s\\S]*?-----END CERTIFICATE-----\\n', '') }}"
+        _cert_intermediate_ca_chain: "{{ r_rhacs_central_tls_secret.resources[0].data['tls.crt'] | b64decode | regex_replace('^[\\s\\S]*?-----END CERTIFICATE-----\\n', '') }}"
+
+    - name: Get cluster trusted CA bundle
+      kubernetes.core.k8s_info:
+        api_version: v1
+        kind: ConfigMap
+        name: trusted-ca-bundle
+        namespace: openshift-config-managed
+      register: r_cluster_trusted_ca_bundle
+
+    - name: Combine intermediate CAs with cluster trust bundle
+      ansible.builtin.set_fact:
+        ocp4_workload_rhacs_reencrypt_destination_ca: "{{ _cert_intermediate_ca_chain }}{{ r_cluster_trusted_ca_bundle.resources[0].data['ca-bundle.crt'] }}"
 
 - name: Create Central
   vars:

--- a/roles/ocp4_workload_rhacs/tasks/workload.yml
+++ b/roles/ocp4_workload_rhacs/tasks/workload.yml
@@ -83,10 +83,7 @@
 
     - name: Extract and process certificate chain
       ansible.builtin.set_fact:
-        ocp4_workload_rhacs_reencrypt_destination_ca: |-
-          {{ r_rhacs_central_tls_secret.resources[0].data['tls.crt']
-             | b64decode
-             | regex_replace('^.*?-----END CERTIFICATE-----\n', '') }}
+        ocp4_workload_rhacs_reencrypt_destination_ca: "{{ r_rhacs_central_tls_secret.resources[0].data['tls.crt'] | b64decode | regex_replace('^[\\s\\S]*?-----END CERTIFICATE-----\\n', '') }}"
 
 - name: Create Central
   vars:

--- a/roles/ocp4_workload_rhacs/tasks/workload.yml
+++ b/roles/ocp4_workload_rhacs/tasks/workload.yml
@@ -83,7 +83,9 @@
 
     - name: Extract intermediate CA chain from certificate
       ansible.builtin.set_fact:
-        _cert_intermediate_ca_chain: "{{ r_rhacs_central_tls_secret.resources[0].data['tls.crt'] | b64decode | regex_replace('^[\\s\\S]*?-----END CERTIFICATE-----\\n', '') }}"
+        _cert_intermediate_ca_chain: >-
+          {{ r_rhacs_central_tls_secret.resources[0].data['tls.crt'] | b64decode |
+             regex_replace('^[\\s\\S]*?-----END CERTIFICATE-----\\n', '') }}
 
     - name: Get cluster trusted CA bundle
       kubernetes.core.k8s_info:

--- a/roles/ocp4_workload_rhacs/templates/central.yaml.j2
+++ b/roles/ocp4_workload_rhacs/templates/central.yaml.j2
@@ -35,6 +35,13 @@ spec:
         enabled: false
       route:
         enabled: true
+{% if ocp4_workload_rhacs_enable_reencrypt_route | bool %}
+        reencrypt:
+          enabled: true
+          tls:
+            destinationCACertificate: |
+{{ ocp4_workload_rhacs_reencrypt_destination_ca | indent(14, first=False) }}
+{% endif %}
     persistence:
       persistentVolumeClaim:
         claimName: stackrox-db

--- a/roles/ocp4_workload_rhacs/templates/central.yaml.j2
+++ b/roles/ocp4_workload_rhacs/templates/central.yaml.j2
@@ -40,7 +40,7 @@ spec:
           enabled: true
           tls:
             destinationCACertificate: |
-{{ ocp4_workload_rhacs_reencrypt_destination_ca | indent(14, first=False) }}
+{{ ocp4_workload_rhacs_reencrypt_destination_ca | indent(14, True) }}
 {% endif %}
     persistence:
       persistentVolumeClaim:


### PR DESCRIPTION
- Add variable ocp4_workload_rhacs_enable_reencrypt_route to enable/disable reencrypt route
- Extract CA certificate chain from rhacs-central-tls secret
- Configure Central CR with reencrypt route and destinationCACertificate
- Hardcoded to use rhacs-central-tls secret name
- Role fails if secret doesn't exist when reencrypt is enabled

The regex removes the first certificate (server cert) from the chain, leaving only the CA certificates needed for backend verification.