### PR TITLE
Skip reencrypt route config if rhacs-central-tls secret does not exist

### DIFF
--- a/roles/ocp4_workload_rhacs/tasks/workload.yml
+++ b/roles/ocp4_workload_rhacs/tasks/workload.yml
@@ -99,7 +99,7 @@
 
     - name: Combine intermediate CAs with cluster trust bundle
       ansible.builtin.set_fact:
-        ocp4_workload_rhacs_reencrypt_destination_ca: >-
+        _ocp4_workload_rhacs_reencrypt_destination_ca: >-
           {{ _cert_intermediate_ca_chain }}{{ r_cluster_trusted_ca_bundle.resources[0].data['ca-bundle.crt'] }}
 
 - name: Create Central

--- a/roles/ocp4_workload_rhacs/tasks/workload.yml
+++ b/roles/ocp4_workload_rhacs/tasks/workload.yml
@@ -69,18 +69,20 @@
   when: ocp4_workload_rhacs_enable_route_certs | bool
   ansible.builtin.include_tasks: certificate.yml
 
-- name: Extract CA certificate chain for reencrypt route
+- name: Get rhacs-central-tls secret for reencrypt route
   when: ocp4_workload_rhacs_enable_reencrypt_route | bool
-  block:
-    - name: Get rhacs-central-tls secret
-      kubernetes.core.k8s_info:
-        api_version: v1
-        kind: Secret
-        name: rhacs-central-tls
-        namespace: "{{ ocp4_workload_rhacs_central_namespace }}"
-      register: r_rhacs_central_tls_secret
-      failed_when: r_rhacs_central_tls_secret.resources | length == 0
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: Secret
+    name: rhacs-central-tls
+    namespace: "{{ ocp4_workload_rhacs_central_namespace }}"
+  register: r_rhacs_central_tls_secret
 
+- name: Extract CA certificate chain for reencrypt route
+  when:
+    - ocp4_workload_rhacs_enable_reencrypt_route | bool
+    - r_rhacs_central_tls_secret.resources | default([]) | length > 0
+  block:
     - name: Extract intermediate CA chain from certificate
       ansible.builtin.set_fact:
         _cert_intermediate_ca_chain: >-

--- a/roles/ocp4_workload_rhacs/templates/central.yaml.j2
+++ b/roles/ocp4_workload_rhacs/templates/central.yaml.j2
@@ -38,9 +38,11 @@ spec:
 {% if ocp4_workload_rhacs_enable_reencrypt_route | bool %}
         reencrypt:
           enabled: true
+{% if ocp4_workload_rhacs_reencrypt_destination_ca is defined %}
           tls:
             destinationCACertificate: |
 {{ ocp4_workload_rhacs_reencrypt_destination_ca | indent(14, True) }}
+{% endif %}
 {% endif %}
     persistence:
       persistentVolumeClaim:

--- a/roles/ocp4_workload_rhacs/templates/central.yaml.j2
+++ b/roles/ocp4_workload_rhacs/templates/central.yaml.j2
@@ -35,14 +35,12 @@ spec:
         enabled: false
       route:
         enabled: true
-{% if ocp4_workload_rhacs_enable_reencrypt_route | bool %}
+{% if ocp4_workload_rhacs_enable_reencrypt_route | bool and _ocp4_workload_rhacs_reencrypt_destination_ca is defined %}
         reencrypt:
           enabled: true
-{% if ocp4_workload_rhacs_reencrypt_destination_ca is defined %}
           tls:
             destinationCACertificate: |
-{{ ocp4_workload_rhacs_reencrypt_destination_ca | indent(14, True) }}
-{% endif %}
+{{ _ocp4_workload_rhacs_reencrypt_destination_ca | indent(14, True) }}
 {% endif %}
     persistence:
       persistentVolumeClaim:


### PR DESCRIPTION
Move secret check outside the block and update block condition to check both reencrypt_route enabled and secret exists. This prevents failure when the secret is not yet created.