### PR TITLE
Exclude Google Trust Services ClusterIssuers when reencrypt route is enabled

### DIFF
--- a/roles/ocp4_workload_rhacs/tasks/certificate.yml
+++ b/roles/ocp4_workload_rhacs/tasks/certificate.yml
@@ -37,13 +37,18 @@
     retries: 5
     delay: 5
 
-  - name: Filter to Ready ClusterIssuers only
+  - name: Filter to Ready ClusterIssuers only (exclude Google Trust Services if reencrypt enabled)
     ansible.builtin.set_fact:
       _ready_cluster_issuers: >-
         {{
-          r_cluster_issuers.resources
+          (r_cluster_issuers.resources
           | json_query("[?status.conditions[?type=='Ready' && status=='True']]")
-          | default([])
+          | rejectattr('spec.acme.server', 'search', '/acme/google/')
+          | list)
+          if ocp4_workload_rhacs_enable_reencrypt_route | bool
+          else (r_cluster_issuers.resources
+          | json_query("[?status.conditions[?type=='Ready' && status=='True']]")
+          | list)
         }}
 
   - name: Fail if no ClusterIssuer is found but certificates are requested


### PR DESCRIPTION
## Summary
- Filter out Google Trust Services ClusterIssuers when `ocp4_workload_rhacs_enable_reencrypt_route` is enabled
- Fixes incompatibility between Google Trust Services certificates and OpenShift reencrypt routes

## Changes
Modified `roles/ocp4_workload_rhacs/tasks/certificate.yml`:
- Updated ClusterIssuer filter on line 40 to exclude issuers with `/acme/google/` in their ACME server URL when reencrypt route is enabled
- Maintains existing behavior when reencrypt route is disabled

## Testing
Tested on clusters with both Google Trust Services and ZeroSSL certificates:
- ✅ Reencrypt route works with ZeroSSL certificates
- ❌ Reencrypt route fails (503) with Google Trust Services certificates
- ✅ Passthrough route works with both certificate providers

## Impact
When `ocp4_workload_rhacs_enable_reencrypt_route: true`, the role will automatically use ZeroSSL, Let's Encrypt, or other non-Google ACME providers for certificate issuance.