### PR TITLE
Fix ClusterIssuer filter to handle non-ACME issuers in RHACS role

### DIFF
--- a/roles/ocp4_workload_rhacs/tasks/certificate.yml
+++ b/roles/ocp4_workload_rhacs/tasks/certificate.yml
@@ -42,8 +42,7 @@
       _ready_cluster_issuers: >-
         {{
           (r_cluster_issuers.resources
-          | json_query("[?status.conditions[?type=='Ready' && status=='True']]")
-          | rejectattr('spec.acme.server', 'search', '/acme/google/')
+          | json_query("[?status.conditions[?type=='Ready' && status=='True'] && (spec.acme.server == null || !contains(spec.acme.server, '/acme/google/'))]")
           | list)
           if ocp4_workload_rhacs_enable_reencrypt_route | bool
           else (r_cluster_issuers.resources


### PR DESCRIPTION
The previous implementation failed when non-ACME ClusterIssuers (e.g., selfsigned) were present because it attempted to access spec.acme.server on all issuers.

Changed from using rejectattr() filter to JMESPath expression that properly handles null values by checking if spec.acme.server exists before testing for Google CA.

When reencrypt route is enabled:
- Filters out Google Trust Services ACME issuers (/acme/google/)
- Keeps all other ACME issuers (ZeroSSL, Let's Encrypt, etc.)
- Keeps all non-ACME issuers (selfsigned, ca, vault, etc.)

When reencrypt route is disabled:
- Keeps all Ready ClusterIssuers (no filtering by CA provider)

Tested against cluster with: acme-bifrost-production-ddns (Google), acme-bifrost-production-ddns-fallback (ZeroSSL), and selfsigned.