### PR TITLE
[ocp4_workload_rhacs] Pre-create CNAME to fix ACME DNS ENT issue on DDNS clusters

### DIFF
--- a/roles/ocp4_workload_rhacs/tasks/dns_cname_pre_cert.yml
+++ b/roles/ocp4_workload_rhacs/tasks/dns_cname_pre_cert.yml
@@ -1,0 +1,54 @@
+---
+# Pre-create a CNAME record for the central route before ACME cert issuance.
+#
+# Problem: When cert-manager runs a DNS-01 ACME challenge for the central route,
+# it creates a _acme-challenge TXT record which creates a DNS Empty Non-Terminal (ENT).
+# The ENT causes the wildcard *.apps.* to stop matching the central hostname,
+# resulting in NODATA and a failed ACME challenge regardless of which issuer is used.
+#
+# Fix: Pre-create a specific CNAME for the central hostname before cert issuance.
+# The CNAME and the _acme-challenge record coexist as siblings — no ENT problem.
+#
+# This task is issuer-agnostic: it finds any ready ClusterIssuer configured with
+# a DDNS webhook and uses its credentials. Silently skips on non-DDNS clusters.
+
+- name: Find ClusterIssuer with DDNS webhook solver
+  kubernetes.core.k8s_info:
+    api_version: cert-manager.io/v1
+    kind: ClusterIssuer
+  register: r_pre_cert_cluster_issuers
+
+- name: Set DDNS issuer fact
+  ansible.builtin.set_fact:
+    _ocp4_workload_rhacs_pre_cert_ddns_issuer: >-
+      {{
+        r_pre_cert_cluster_issuers.resources
+        | json_query("[?spec.acme.solvers[?dns01.webhook.config.ddnsServer]]")
+        | first | default({})
+      }}
+
+- name: Pre-create CNAME record to prevent DNS ENT issue during ACME challenge
+  when: _ocp4_workload_rhacs_pre_cert_ddns_issuer | length > 0
+  vars:
+    _solver: "{{ _ocp4_workload_rhacs_pre_cert_ddns_issuer.spec.acme.solvers[0].dns01.webhook.config }}"
+  block:
+  - name: Get TSIG secret from cert-manager namespace
+    kubernetes.core.k8s_info:
+      api_version: v1
+      kind: Secret
+      name: "{{ _solver.tsigSecretRef.name }}"
+      namespace: cert-manager
+    register: r_pre_cert_tsig_secret
+
+  - name: Create CNAME record for central route
+    community.general.nsupdate:
+      server: "{{ _solver.ddnsServer }}"
+      zone: "{{ _solver.ddnsZone }}"
+      record: "central-{{ ocp4_workload_rhacs_central_namespace }}.{{ openshift_cluster_ingress_domain | regex_replace('\\.' + _solver.ddnsZone + '$', '') }}"
+      type: CNAME
+      ttl: 30
+      value: "console-openshift-console.{{ openshift_cluster_ingress_domain }}."
+      key_name: "{{ _solver.tsigKeyName }}"
+      key_secret: "{{ r_pre_cert_tsig_secret.resources[0].data[_solver.tsigSecretRef.key] | b64decode }}"
+      key_algorithm: "{{ _solver.tsigAlgorithm }}"
+      state: present

--- a/roles/ocp4_workload_rhacs/tasks/dns_cname_pre_cert.yml
+++ b/roles/ocp4_workload_rhacs/tasks/dns_cname_pre_cert.yml
@@ -9,16 +9,32 @@
 # Fix: Pre-create a specific CNAME for the central hostname before cert issuance.
 # The CNAME and the _acme-challenge record coexist as siblings — no ENT problem.
 #
+# Only runs on non-BareMetal platforms. BareMetal clusters use an explicit A record
+# created by dns_registration.yml after Central is deployed — a CNAME would conflict.
+#
 # This task is issuer-agnostic: it finds any ready ClusterIssuer configured with
 # a DDNS webhook and uses its credentials. Silently skips on non-DDNS clusters.
 
+- name: Get cluster infrastructure platform
+  kubernetes.core.k8s_info:
+    api_version: config.openshift.io/v1
+    kind: Infrastructure
+    name: cluster
+  register: r_pre_cert_infrastructure
+
+- name: Set platform fact
+  ansible.builtin.set_fact:
+    _ocp4_workload_rhacs_pre_cert_platform: "{{ r_pre_cert_infrastructure.resources[0].status.platform | default('Unknown') }}"
+
 - name: Find ClusterIssuer with DDNS webhook solver
+  when: _ocp4_workload_rhacs_pre_cert_platform not in ["BareMetal", "None"]
   kubernetes.core.k8s_info:
     api_version: cert-manager.io/v1
     kind: ClusterIssuer
   register: r_pre_cert_cluster_issuers
 
 - name: Set DDNS issuer fact
+  when: _ocp4_workload_rhacs_pre_cert_platform not in ["BareMetal", "None"]
   ansible.builtin.set_fact:
     _ocp4_workload_rhacs_pre_cert_ddns_issuer: >-
       {{
@@ -28,7 +44,9 @@
       }}
 
 - name: Pre-create CNAME record to prevent DNS ENT issue during ACME challenge
-  when: _ocp4_workload_rhacs_pre_cert_ddns_issuer | length > 0
+  when:
+    - _ocp4_workload_rhacs_pre_cert_platform not in ["BareMetal", "None"]
+    - _ocp4_workload_rhacs_pre_cert_ddns_issuer | default({}) | length > 0
   vars:
     _solver: "{{ _ocp4_workload_rhacs_pre_cert_ddns_issuer.spec.acme.solvers[0].dns01.webhook.config }}"
   block:

--- a/roles/ocp4_workload_rhacs/tasks/workload.yml
+++ b/roles/ocp4_workload_rhacs/tasks/workload.yml
@@ -65,6 +65,10 @@
   retries: 30
   delay: 5
 
+- name: Pre-create CNAME record before ACME cert issuance
+  when: ocp4_workload_rhacs_enable_route_certs | bool
+  ansible.builtin.include_tasks: dns_cname_pre_cert.yml
+
 - name: Set up Certificate for Central
   when: ocp4_workload_rhacs_enable_route_certs | bool
   ansible.builtin.include_tasks: certificate.yml


### PR DESCRIPTION
## Problem

On DDNS clusters (`dyn.redhatworkshops.io`), the `central` route always ends up with a self-signed certificate despite having ACME ClusterIssuers available (Google CA, ZeroSSL).

**Root cause — DNS Empty Non-Terminal (ENT):**

When cert-manager runs a DNS-01 ACME challenge for `central-stackrox.apps.cluster-<guid>.dyn.redhatworkshops.io`, it creates:
```
_acme-challenge.central-stackrox.apps.cluster-<guid>.dyn.redhatworkshops.io  TXT  "token"
```
This TXT record creates an ENT at `central-stackrox.apps.cluster-<guid>` in the DNS tree. Because the name now "exists", the wildcard `*.apps.cluster-<guid>` no longer matches it — the hostname returns `NODATA` instead of the router IP. The ACME challenge fails for **all issuers** (Google and ZeroSSL both use the same DDNS solver), and cert issuance falls back to `selfsigned`.

## Fix

New task file `dns_cname_pre_cert.yml` pre-creates a specific CNAME record for the central route **before** cert issuance:

```
central-stackrox.apps.cluster-<guid>  CNAME  console-openshift-console.apps.cluster-<guid>.dyn.redhatworkshops.io.
```

The CNAME and the `_acme-challenge` TXT record coexist as siblings in the DNS zone — no ENT problem. The ACME challenge resolves correctly and a trusted certificate is issued.

Called from `workload.yml` immediately before `certificate.yml`.

## Changes

**`roles/ocp4_workload_rhacs/tasks/dns_cname_pre_cert.yml`** _(new file)_
- Checks cluster infrastructure platform — skips entirely on `BareMetal` and `None` (SNO) to avoid conflicting with the A record that `dns_registration.yml` creates after Central is deployed
- Finds any ClusterIssuer with a DDNS webhook using `json_query` — no hardcoded issuer names
- Silently skips if no DDNS-capable ClusterIssuer is found (AWS Route53, GCP, Azure)
- Reads all TSIG config (`tsigAlgorithm`, `tsigKeyName`, `tsigSecretRef`, `ddnsServer`, `ddnsZone`) directly from the ClusterIssuer — nothing hardcoded
- Creates the CNAME using `community.general.nsupdate`

**`roles/ocp4_workload_rhacs/tasks/workload.yml`** _(modified)_
- Added 4 lines to include `dns_cname_pre_cert.yml` immediately before `certificate.yml`, gated on `ocp4_workload_rhacs_enable_route_certs`

## Platform behaviour

| Platform | Result |
|---|---|
| CNV / OcpSandbox | CNAME pre-created — ACME succeeds |
| AWS | No DDNS issuer found → block skipped |
| GCP / Azure | No DDNS issuer found → block skipped |
| BareMetal / SNO | Platform guard skips — `dns_registration.yml` creates A record after deploy |

BareMetal clusters are explicitly excluded because `dns_registration.yml` already creates an **A record** for the same hostname after Central is deployed. A CNAME and an A record cannot coexist for the same name (RFC 1034).

## Notes

- `dns_registration.yml` is unchanged — BareMetal A record logic unaffected
- Alternative to PR #136 — same problem solved, keeps DNS logic out of `certificate.yml`
- TSIG creds are per-cluster not per-CA: both `acme-bifrost-production-ddns` and `acme-bifrost-production-ddns-fallback` share the same DDNS server, zone, and `cert-manager-tsig-creds` secret — the CNAME benefits whichever issuer runs the ACME challenge

## Test plan

- [ ] Provision an RHACS catalog item on a CNV/DDNS cluster — verify `central` route gets a trusted (non-selfsigned) cert
- [ ] Provision on an AWS cluster — verify the CNAME task skips silently and provisioning completes normally
- [ ] Provision on a BareMetal cluster — verify BareMetal A record logic in `dns_registration.yml` still works