### PR TITLE
Add ROSA support to ocp4_workload_authentication

### DIFF
--- a/roles/ocp4_workload_authentication/defaults/main.yml
+++ b/roles/ocp4_workload_authentication/defaults/main.yml
@@ -160,3 +160,11 @@ ocp4_workload_authentication_keycloak_clients: []
 #   description: "Grafana OAuth Client"
 
 ocp4_workload_authentication_keycloak_enable_user_info_messages: true
+
+# --------------------------------
+# ROSA Settings
+# --------------------------------
+
+# ROSA cluster name for `rosa create idp` command.
+# Defaults to rosa-{{ guid }} if not set.
+# ocp4_workload_authentication_rosa_cluster_name: "rosa-{{ guid }}"

--- a/roles/ocp4_workload_authentication/defaults/main.yml
+++ b/roles/ocp4_workload_authentication/defaults/main.yml
@@ -97,27 +97,19 @@ ocp4_workload_authentication_htpasswd_secret_name: htpasswd
 
 ocp4_workload_authentication_keycloak_namespace: keycloak
 
-ocp4_workload_authentication_keycloak_pgsql_user: keycloak
+ocp4_workload_authentication_keycloak_channel: stable-v26.2
+ocp4_workload_authentication_keycloak_automatic_install_plan_approval: true
+ocp4_workload_authentication_keycloak_starting_csv: ""
+ocp4_workload_authentication_keycloak_use_catalog_source: false
+ocp4_workload_authentication_keycloak_catalogsource_image: quay.io/rhpds/olm_snapshot_redhat_catalog
+ocp4_workload_authentication_keycloak_catalogsource_tag: v4.20_2026_02_11
 
+ocp4_workload_authentication_keycloak_pgsql_user: keycloak
 # Postgres database password for keycloak. Password generated if empty.
 ocp4_workload_authentication_keycloak_pgsql_password: ""
 
-ocp4_workload_authentication_keycloak_channel: stable-v26.2
-
-ocp4_workload_authentication_keycloak_automatic_install_plan_approval: true
-
-ocp4_workload_authentication_keycloak_starting_csv: ""
-
-ocp4_workload_authentication_keycloak_use_catalog_source: false
-
-ocp4_workload_authentication_keycloak_catalogsource_image: quay.io/rhpds/olm_snapshot_redhat_catalog
-
-ocp4_workload_authentication_keycloak_catalogsource_tag: v4.20_2026_02_11
-
 ocp4_workload_authentication_keycloak_default_realm: sso
-
 ocp4_workload_authentication_keycloak_openshift_client_secret: ""
-
 ocp4_workload_authentication_keycloak_openshift_client_id: idp-4-ocp
 
 # --------------------------------

--- a/roles/ocp4_workload_authentication/tasks/remove_workload.yml
+++ b/roles/ocp4_workload_authentication/tasks/remove_workload.yml
@@ -1,5 +1,28 @@
 ---
+- name: Detect ROSA cluster
+  block:
+  - name: Get cluster infrastructure info
+    kubernetes.core.k8s_info:
+      api_version: config.openshift.io/v1
+      kind: Infrastructure
+      name: cluster
+    register: r_cluster_infrastructure
+
+  - name: Set auth method based on cluster type
+    vars:
+      _resource_tags: >-
+        {{ r_cluster_infrastructure.resources[0].status.platformStatus[
+          r_cluster_infrastructure.resources[0].status.platformStatus.type | lower
+        ].resourceTags | default([]) }}
+      _cluster_type: >-
+        {{ _resource_tags | selectattr('key', 'equalto', 'red-hat-clustertype')
+          | map(attribute='value') | first | default('') }}
+    ansible.builtin.set_fact:
+      _ocp4_workload_authentication_auth_method: >-
+        {{ 'rosa' if _cluster_type == 'rosa' else '' }}
+
 - name: Remove Keycloak Namespace
+  when: ocp4_workload_authentication_provider == 'keycloak'
   kubernetes.core.k8s:
     state: absent
     api_version: v1
@@ -7,6 +30,7 @@
     name: "{{ ocp4_workload_authentication_keycloak_namespace }}"
 
 - name: Reset OAuth cluster configuration
+  when: _ocp4_workload_authentication_auth_method != 'rosa'
   kubernetes.core.k8s:
     resource_definition:
       apiVersion: config.openshift.io/v1
@@ -15,3 +39,12 @@
         name: cluster
       spec:
         identityProviders: []
+
+- name: Remove ROSA identity provider
+  when: _ocp4_workload_authentication_auth_method == 'rosa'
+  delegate_to: "{{ groups['bastions'][0] }}"
+  ansible.builtin.command: >-
+    rosa delete idp {{ ocp4_workload_authentication_keycloak_default_realm }}
+    --cluster {{ ocp4_workload_authentication_rosa_cluster_name | default('rosa-' ~ guid) }}
+    --yes
+  failed_when: false

--- a/roles/ocp4_workload_authentication/tasks/setup_keycloak.yml
+++ b/roles/ocp4_workload_authentication/tasks/setup_keycloak.yml
@@ -88,7 +88,8 @@
   delay: 10
   until: r_keycloak_instance is not failed
 
-- name: Create Openshift auth resources
+- name: Create OpenShift auth resources (OAuth CRD)
+  when: _ocp4_workload_authentication_auth_method != 'rosa'
   kubernetes.core.k8s:
     state: present
     template: "{{ item }}"
@@ -99,6 +100,30 @@
   retries: 5
   delay: 10
   until: r_openshift_auth is success
+
+- name: Create OpenShift identity provider (ROSA)
+  when: _ocp4_workload_authentication_auth_method == 'rosa'
+  delegate_to: "{{ groups['bastions'][0] }}"
+  block:
+  - name: Delete existing ROSA IdP if present
+    ansible.builtin.command: >-
+      rosa delete idp {{ ocp4_workload_authentication_keycloak_default_realm }}
+      --cluster {{ ocp4_workload_authentication_rosa_cluster_name | default('rosa-' ~ guid) }}
+      --yes
+    failed_when: false
+
+  - name: Create ROSA OpenID identity provider
+    ansible.builtin.command: >-
+      rosa create idp
+      --cluster {{ ocp4_workload_authentication_rosa_cluster_name | default('rosa-' ~ guid) }}
+      --type openid
+      --name {{ ocp4_workload_authentication_keycloak_default_realm }}
+      --client-id {{ ocp4_workload_authentication_keycloak_openshift_client_id }}
+      --client-secret {{ _ocp4_workload_authentication_keycloak_openshift_client_secret }}
+      --issuer-url https://sso.{{ openshift_cluster_ingress_domain }}/realms/{{ ocp4_workload_authentication_keycloak_default_realm }}
+      --email-claims email
+      --name-claims name
+      --username-claims preferred_username
 
 - name: Retrieve Keycloak admin credentials
   kubernetes.core.k8s_info:

--- a/roles/ocp4_workload_authentication/tasks/workload.yml
+++ b/roles/ocp4_workload_authentication/tasks/workload.yml
@@ -1,4 +1,35 @@
 ---
+- name: Detect ROSA cluster
+  block:
+  - name: Get cluster infrastructure info
+    kubernetes.core.k8s_info:
+      api_version: config.openshift.io/v1
+      kind: Infrastructure
+      name: cluster
+    register: r_cluster_infrastructure
+
+  - name: Set auth method based on cluster type
+    vars:
+      _resource_tags: >-
+        {{ r_cluster_infrastructure.resources[0].status.platformStatus[
+          r_cluster_infrastructure.resources[0].status.platformStatus.type | lower
+        ].resourceTags | default([]) }}
+      _cluster_type: >-
+        {{ _resource_tags | selectattr('key', 'equalto', 'red-hat-clustertype')
+          | map(attribute='value') | first | default('') }}
+    ansible.builtin.set_fact:
+      _ocp4_workload_authentication_auth_method: >-
+        {{ 'rosa' if _cluster_type == 'rosa' else '' }}
+
+- name: Fail if htpasswd is selected on ROSA
+  when:
+  - _ocp4_workload_authentication_auth_method == 'rosa'
+  - ocp4_workload_authentication_provider == 'htpasswd'
+  ansible.builtin.fail:
+    msg: >-
+      HTPasswd authentication is not supported on ROSA clusters.
+      Set ocp4_workload_authentication_provider to 'keycloak'.
+
 - name: Setup passwords
   ansible.builtin.include_tasks: setup_passwords.yml
 
@@ -14,8 +45,21 @@
   ansible.builtin.include_tasks: setup_cluster_role_bindings.yml
 
 - name: Remove kubeadmin user
-  when: ocp4_workload_authentication_remove_kubeadmin | bool
+  when:
+  - ocp4_workload_authentication_remove_kubeadmin | bool
+  - _ocp4_workload_authentication_auth_method != 'rosa'
   ansible.builtin.include_tasks: remove_kubeadmin_user.yml
+
+- name: Remove ROSA cluster-admin user
+  when:
+  - ocp4_workload_authentication_remove_kubeadmin | bool
+  - _ocp4_workload_authentication_auth_method == 'rosa'
+  delegate_to: "{{ groups['bastions'][0] }}"
+  ansible.builtin.command: >-
+    rosa delete admin
+    --cluster {{ ocp4_workload_authentication_rosa_cluster_name | default('rosa-' ~ guid) }}
+    --yes
+  failed_when: false
 
 - name: Report provision data and messages
   ansible.builtin.include_tasks: report_data_and_messages.yml


### PR DESCRIPTION
## Summary

- Auto-detects ROSA clusters via `Infrastructure` resource tags (`red-hat-clustertype: rosa`)
- Uses `rosa create idp --type openid` instead of OAuth CRD for Keycloak integration on ROSA (OAuth CRD is not supported on managed ROSA clusters)
- Fails early with clear message if htpasswd provider is selected on ROSA
- Deletes ROSA HTPasswd admin user when `ocp4_workload_authentication_remove_kubeadmin: true`
- `rosa create idp` / `rosa delete idp` commands are delegated to bastion (ROSA CLI session not available in EE)
- No changes to IPI/non-ROSA clusters — existing behavior is unchanged