### PR TITLE
feat: allow AAP2 manifest injection via internal service URL

### DIFF
--- a/roles/ocp4_workload_ansible_automation_platform/defaults/main.yml
+++ b/roles/ocp4_workload_ansible_automation_platform/defaults/main.yml
@@ -39,6 +39,12 @@ ocp4_workload_ansible_automation_platform_token_lifecycle_retries: 5
 ocp4_workload_ansible_automation_platform_deploy_wait_timeout: 1800
 ocp4_workload_ansible_automation_platform_manifest_inject_retries: 3
 ocp4_workload_ansible_automation_platform_manifest_inject_delay: 5
+# Override to use an internal service URL for manifest injection.
+# When set, bypasses the external route hostname (useful when ingress
+# is slow to come up or unreachable from the deployer pod).
+# Example: "aap.aap.svc.cluster.local"
+ocp4_workload_ansible_automation_platform_manifest_inject_host: ""
+ocp4_workload_ansible_automation_platform_manifest_inject_validate_certs: true
 # Additional manifest overrides to be merged into the Template used to deploy AAP
 ocp4_workload_ansible_automation_platform_aap_manifest_overrides: {}
 

--- a/roles/ocp4_workload_ansible_automation_platform/tasks/workload.yml
+++ b/roles/ocp4_workload_ansible_automation_platform/tasks/workload.yml
@@ -91,10 +91,13 @@
   - name: Inject AAP2 Controller manifest
     ansible.controller.license:
       manifest: /tmp/aap-manifest.zip
-      controller_host: "{{ automation_controller_hostname }}"
+      controller_host: >-
+        {{ ocp4_workload_ansible_automation_platform_manifest_inject_host
+           if ocp4_workload_ansible_automation_platform_manifest_inject_host | default('') | length > 0
+           else automation_controller_hostname }}
       controller_username: admin
       controller_password: "{{ _ocp4_workload_ansible_automation_platform_admin_password }}"
-      validate_certs: true
+      validate_certs: "{{ ocp4_workload_ansible_automation_platform_manifest_inject_validate_certs }}"
     register: r_aap_license
     until: not r_aap_license.failed
     retries: "{{ ocp4_workload_ansible_automation_platform_manifest_inject_retries }}"


### PR DESCRIPTION
## Summary

- Adds `ocp4_workload_ansible_automation_platform_manifest_inject_host` to override the controller host for license injection (e.g. `aap.aap.svc.cluster.local`)
- Adds `ocp4_workload_ansible_automation_platform_manifest_inject_validate_certs` to allow disabling TLS when using internal HTTP endpoints
- Fully backward-compatible: defaults are empty string and `true`, matching current behavior

## Problem

When the deployer runs as a pod inside the cluster, manifest injection connects to the AAP controller via its external Route hostname. If the cluster ingress is slow to come up or the load balancer is misconfigured (Connection refused), manifest injection fails even though the controller API is healthy on the internal network.

We've hit this repeatedly on IBM Cloud shared clusters where the ingress VIP is unreachable during provisioning.

## Usage

In agnosticv, set:
```yaml
ocp4_workload_ansible_automation_platform_manifest_inject_host: "aap.aap.svc.cluster.local"
ocp4_workload_ansible_automation_platform_manifest_inject_validate_certs: false
ocp4_workload_ansible_automation_platform_manifest_inject_retries: 60
ocp4_workload_ansible_automation_platform_manifest_inject_delay: 10
```

## Test plan

- [ ] Deploy with defaults (no override) — behavior identical to before
- [ ] Deploy with `manifest_inject_host` set to internal URL — manifest injection uses internal service, bypasses route
- [ ] Verify AAP console still accessible via external route after provisioning

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>