### PR TITLE
Add subscription config support to OpenShift GitOps workload

### DIFF
--- a/roles/ocp4_workload_openshift_gitops/defaults/main.yml
+++ b/roles/ocp4_workload_openshift_gitops/defaults/main.yml
@@ -182,3 +182,15 @@ ocp4_workload_openshift_gitops_catalog_snapshot_image: quay.io/rhpds/olm_snapsho
 
 # Catalog snapshot image tag
 ocp4_workload_openshift_gitops_catalog_snapshot_image_tag: v4.19_2025_07_21
+
+# ----------------------------------
+# Subscription Configuration
+# ----------------------------------
+# Additional subscription configuration to pass to the operator
+# This is useful for setting environment variables like ARGOCD_CLUSTER_CONFIG_NAMESPACES
+# Example:
+# ocp4_workload_openshift_gitops_subscription_config:
+#   env:
+#   - name: ARGOCD_CLUSTER_CONFIG_NAMESPACES
+#     value: "openshift-gitops,custom-namespace"
+ocp4_workload_openshift_gitops_subscription_config: {}

--- a/roles/ocp4_workload_openshift_gitops/tasks/workload.yml
+++ b/roles/ocp4_workload_openshift_gitops/tasks/workload.yml
@@ -19,6 +19,7 @@
     install_operator_catalogsource_namespace: openshift-gitops-operator
     install_operator_catalogsource_image: "{{ ocp4_workload_openshift_gitops_catalog_snapshot_image | default('') }}"
     install_operator_catalogsource_image_tag: "{{ ocp4_workload_openshift_gitops_catalog_snapshot_image_tag | default('') }}"
+    install_operator_subscription_config: "{{ ocp4_workload_openshift_gitops_subscription_config }}"
 
 - name: Grant cluster-admin permissions to Gitops Service account
   when: ocp4_workload_openshift_gitops_setup_cluster_admin | bool


### PR DESCRIPTION
Allow passing custom subscription configuration to the install_operator role via ocp4_workload_openshift_gitops_subscription_config variable. This enables setting environment variables like ARGOCD_CLUSTER_CONFIG_NAMESPACES to allow the GitOps operator to watch multiple namespaces.

Defaults to empty dict {} which is properly handled by the install_operator template's length check.