### PR TITLE
feat(keycloak): support service account client role mappings

### DIFF
--- a/roles/ocp4_workload_authentication/defaults/main.yml
+++ b/roles/ocp4_workload_authentication/defaults/main.yml
@@ -135,6 +135,9 @@ ocp4_workload_authentication_keycloak_openshift_client_id: idp-4-ocp
 #   - standardFlowEnabled: true/false (optional, defaults to true)
 #   - directAccessGrantsEnabled: true/false (optional, defaults to true)
 #   - serviceAccountsEnabled: true/false (optional, defaults to true)
+#   - serviceAccountRoles: dict of client-name → role list (optional)
+#     Assigns client roles to the service account user created by Keycloak.
+#     Only used when serviceAccountsEnabled is true.
 
 ocp4_workload_authentication_keycloak_clients: []
 
@@ -158,5 +161,19 @@ ocp4_workload_authentication_keycloak_clients: []
 #   redirectUris:
 #   - "https://grafana.{{ openshift_cluster_ingress_domain }}/login/generic_oauth"
 #   description: "Grafana OAuth Client"
+
+# Example: RHDH Keycloak Plugin with service account roles
+# The keycloakOrg catalog provider requires realm-management roles
+# to sync users and groups into the Developer Hub catalog.
+# ocp4_workload_authentication_keycloak_clients:
+# - clientId: backstage-plugin
+#   secret: "{{ lookup('password', '/dev/null chars=ascii_letters,digits length=32') }}"
+#   standardFlowEnabled: false
+#   serviceAccountsEnabled: true
+#   serviceAccountRoles:
+#     realm-management:
+#       - query-users
+#       - view-users
+#       - query-groups
 
 ocp4_workload_authentication_keycloak_enable_user_info_messages: true

--- a/roles/ocp4_workload_authentication/templates/keycloak/realm_import.yml.j2
+++ b/roles/ocp4_workload_authentication/templates/keycloak/realm_import.yml.j2
@@ -59,8 +59,23 @@ spec:
           description: "Default user role"
         - name: admin
           description: "Administrator role"
-{% if ocp4_workload_authentication_num_users | int > 0 or _ocp4_workload_authentication_cluster_accounts | length > 0 %}
+{% set _has_service_account_roles = ocp4_workload_authentication_keycloak_clients | selectattr('serviceAccountRoles', 'defined') | list | length > 0 %}
+{% if ocp4_workload_authentication_num_users | int > 0 or _ocp4_workload_authentication_cluster_accounts | length > 0 or _has_service_account_roles %}
     users:
+{% for client in ocp4_workload_authentication_keycloak_clients %}
+{% if client.serviceAccountRoles is defined %}
+      - username: service-account-{{ client.clientId }}
+        enabled: true
+        serviceAccountClientId: {{ client.clientId }}
+        clientRoles:
+{% for client_name, roles in client.serviceAccountRoles.items() %}
+          {{ client_name }}:
+{% for role in roles %}
+            - {{ role }}
+{% endfor %}
+{% endfor %}
+{% endif %}
+{% endfor %}
 {% for _account in _ocp4_workload_authentication_cluster_accounts %}
       - username: {{ _account.name }}
         enabled: true


### PR DESCRIPTION
The PR adds one optional field (serviceAccountRoles) to the **ocp4_workload_authentication_keycloak_clients** variable.

## Problem
When you create a Keycloak client with serviceAccountsEnabled: true, Keycloak automatically creates a service account user — but the realm import template has no way to assign client roles to it. This matters for plugins like the RHDH keycloakOrg provider, which needs query-users, view-users, and query-groups on the realm-management client.

##   Change
If a client entry includes a serviceAccountRoles dict, the template adds the service account user to the realm import's users section with the specified clientRoles. If the field isn't defined, behavior is unchanged.

Usage:

```
  ocp4_workload_authentication_keycloak_clients:
  - clientId: backstage-plugin
    secret: "{{ some_secret }}"
    serviceAccountsEnabled: true
    serviceAccountRoles:
      realm-management:
        - query-users
        - view-users
        - query-groups
```
