### PR TITLE
[GPTEINFRA-16720] Fix showroom failure on no-bastion labs (DevSpaces, OCP Virt)

### DIFF
--- a/roles/ocp4_workload_multi_tenant_loop/tasks/provision_user.yml
+++ b/roles/ocp4_workload_multi_tenant_loop/tasks/provision_user.yml
@@ -1,5 +1,4 @@
 ---
-# =========================================================================
 # Run all tenant workloads for a single user (Phase 1).
 #
 # VARIABLE SCOPING:
@@ -17,7 +16,6 @@
 #
 # No agnosticd_user_info calls here — registration is in Phase 2.
 # See workload.yml header for why two-phase is necessary.
-# =========================================================================
 
 - name: "Set identity: {{ tenant_user_prefix ~ _tenant_user_num }}"
   ansible.builtin.set_fact:

--- a/roles/ocp4_workload_multi_tenant_loop/tasks/provision_user.yml
+++ b/roles/ocp4_workload_multi_tenant_loop/tasks/provision_user.yml
@@ -92,9 +92,25 @@
     dest: "{{ output_dir }}/provision-user-data.yaml"
     mode: '0644'
 
-- name: "Reset _showroom_user_data fact to prevent dirty in-memory combine: {{ _tenant_username }}"
+- name: "Strip users key from _showroom_user_data fact to prevent dirty in-memory combine: {{ _tenant_username }}"
+  # Remove ONLY the users key — resetting to {} would wipe role defaults such as
+  # bastion_public_hostname: 'test_hostname' (from showroom vars/main.yml), breaking
+  # labs without a bastion (e.g. DevSpaces-only labs). Stripping just the users key
+  # is sufficient: combine() in prepare_variables.yaml then merges from a clean slate
+  # that still carries role-level defaults.
+  when:
+  - _showroom_user_data is defined
+  - _showroom_user_data is mapping
+  - _showroom_user_data.users is defined
   ansible.builtin.set_fact:
-    _showroom_user_data: {}
+    _showroom_user_data: >-
+      {{
+        _showroom_user_data
+        | dict2items
+        | rejectattr('key', 'equalto', 'users')
+        | list
+        | items2dict
+      }}
 # ─────────────────────────────────────────────────────────────────────────────
 
 - name: "Provision workloads: {{ _tenant_username }}"


### PR DESCRIPTION
## Problem

Labs without a bastion (LB2236 Ansible Dev Tools DevSpaces, LB2391 Modernize OCP Virt) fail with:

```
'dict object' has no attribute 'bastion_public_hostname'
```

## Root Cause

The bridge role's `set_fact: _showroom_user_data: {}` reset wipes the showroom role's `vars/main.yml` default (`bastion_public_hostname: 'test_hostname'`). `set_fact` has higher precedence than role vars — once reset to `{}`, the default is gone. Labs WITH a bastion work because `provision-user-data.yaml` supplies the value. Labs WITHOUT a bastion crash when the helm chart values are rendered.

## Fix

Strip only the `users` key instead of full reset. Three guards per council + external model review:
- `_showroom_user_data is defined` — safe skip on first iteration
- `_showroom_user_data is mapping` — guard against non-dict edge case  
- `_showroom_user_data.users is defined` — only strip when fact is dirty

Preserves `bastion_public_hostname` and all other role defaults while preventing multi-user mode trigger.

## Validated

- LB2863 (with bastion): multi-user fix confirmed working
- LB2236/LB2391 (no bastion): fix for regression from {} reset

Jira: GPTEINFRA-16720