### PR TITLE
Extend RHACS Central route wait to ride out DNS negative caching

### DIFF
--- a/roles/ocp4_workload_rhacs/tasks/workload.yml
+++ b/roles/ocp4_workload_rhacs/tasks/workload.yml
@@ -182,8 +182,11 @@
     status_code: 200
   register: r_stackrox_central_check
   until: r_stackrox_central_check.status == 200
-  retries: 60
-  delay: 5
+  # 30 minutes: a transient NXDOMAIN for the route hostname can be
+  # negative-cached along the resolver chain well past the old 5-minute
+  # budget (dyn.redhatworkshops.io SOA minimum is 24h)
+  retries: 90
+  delay: 20
 
 # ACS Secured Cluster (Sensor) Installation
 - name: Get cluster init bundle


### PR DESCRIPTION
The ocp4_workload_rhacs task 'Wait for StackRox Central to return 200 status' retried for about 5 minutes (60 x 5s). A transient NXDOMAIN for the *.apps route hostname gets negative-cached along the resolver chain — dyn.redhatworkshops.io publishes SOA minimum 86400 (24h) — so a momentary resolution blip at first query can outlast the entire retry budget and fail the provision, even though the wildcard record exists on both authoritative servers.

Observed on prod1 (apps.ocpv-infra02.wdc07) jobs 40181 (2026-07-15) and 37175 (2026-07-14), both agd-v2.rhacs-demo-cnv: 60 consecutive attempts over 5m23s all failed with 'Name or service not known' for central-stackrox.apps.cluster-<guid>.dyn.redhatworkshops.io while api.cluster-<guid> resolved fine in the same job, and 14 live pool clusters resolved correctly on both ddns01 and ddns02 during investigation.

This change extends the wait to 30 minutes (90 x 20s), which outlasts typical resolver negative-cache windows (OpenShift CoreDNS denial cache caps at 900s). No happy-path cost: the task exits on the first 200.

A companion infra request is being filed to lower the SOA minimum on dyn.redhatworkshops.io, which addresses the root cause for all items using that zone.

Deployment note: dev stage of agd-v2.rhacs-demo-cnv tracks main for collections; prod pins tag rhacs-demo-cnv-1.0.1 and needs a 1.0.2 tag plus an agnosticv prod.yaml bump to pick this up.