### PR TITLE
Add option to use private git repos in field source content

### DIFF
--- a/roles/ocp4_workload_field_content/defaults/main.yml
+++ b/roles/ocp4_workload_field_content/defaults/main.yml
@@ -16,6 +16,15 @@
 ocp4_workload_field_content_gitops_repo_url: ""
 
 # -----------------------------------------------------------------------------
+# Optional: GitHub PAT or access token for private repositories
+# -----------------------------------------------------------------------------
+# When provided, creates an ArgoCD repository secret so it can clone the repo.
+# For GitHub: use a Personal Access Token (PAT) with repo scope.
+# For GitLab: use a Project Access Token or PAT with read_repository scope.
+# Leave empty for public repositories.
+ocp4_workload_field_content_gitops_repo_key: ""
+
+# -----------------------------------------------------------------------------
 # Optional: Git revision and path
 # -----------------------------------------------------------------------------
 # Git branch, tag, or commit to deploy

--- a/roles/ocp4_workload_field_content/tasks/workload.yml
+++ b/roles/ocp4_workload_field_content/tasks/workload.yml
@@ -30,6 +30,15 @@
     _litemaas_available: false
 
 # ===================================================================
+# Register private repo credentials with ArgoCD (if key provided)
+# ===================================================================
+- name: Create ArgoCD repository secret for private repo
+  kubernetes.core.k8s:
+    state: present
+    template: repository-secret.yaml.j2
+  when: ocp4_workload_field_content_gitops_repo_key | default('') | length > 0
+
+# ===================================================================
 # Build Helm values
 # ===================================================================
 - name: Set deployer values (always included)

--- a/roles/ocp4_workload_field_content/templates/repository-secret.yaml.j2
+++ b/roles/ocp4_workload_field_content/templates/repository-secret.yaml.j2
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: field-content-repo-credentials
+  namespace: {{ ocp4_workload_field_content_namespace }}
+  labels:
+    argocd.argoproj.io/secret-type: repository
+stringData:
+  type: git
+  url: "{{ ocp4_workload_field_content_gitops_repo_url }}"
+  username: "git"
+  password: "{{ ocp4_workload_field_content_gitops_repo_key }}"


### PR DESCRIPTION
sometimes gitops repo is private. this will create the secret based on a var provided in the order form and then do all the gitopsiness the same way.