### PR TITLE
feat(gitops_bootstrap): add configurable sync_options

### DIFF
--- a/roles/ocp4_workload_gitops_bootstrap/defaults/main.yml
+++ b/roles/ocp4_workload_gitops_bootstrap/defaults/main.yml
@@ -49,3 +49,11 @@ ocp4_workload_gitops_bootstrap_application_sync_required: true # false is great 
 # /operation on child Application CRDs. Has no effect on other resource types.
 # Default: false — existing labs are unaffected unless they opt in.
 ocp4_workload_gitops_bootstrap_application_ignore_tracking: false
+
+# Additional syncOptions to include on the ArgoCD Application.
+# RespectIgnoreDifferences=true is always included.
+# Common additions:
+#   - SkipDryRunOnMissingResource=true  (when operator CRDs are in same app as Subscriptions)
+#   - CreateNamespace=true
+#   - ServerSideApply=true
+ocp4_workload_gitops_bootstrap_sync_options: []

--- a/roles/ocp4_workload_gitops_bootstrap/templates/application.yaml.j2
+++ b/roles/ocp4_workload_gitops_bootstrap/templates/application.yaml.j2
@@ -33,9 +33,11 @@ spec:
       selfHeal: false
     syncOptions:
       - RespectIgnoreDifferences=true
+{% if ocp4_workload_gitops_bootstrap_sync_options | length > 0 %}
 {% for opt in ocp4_workload_gitops_bootstrap_sync_options %}
       - {{ opt }}
 {% endfor %}
+{% endif %}
   ignoreDifferences:
     - group: ""
       kind: ConfigMap

--- a/roles/ocp4_workload_gitops_bootstrap/templates/application.yaml.j2
+++ b/roles/ocp4_workload_gitops_bootstrap/templates/application.yaml.j2
@@ -33,6 +33,9 @@ spec:
       selfHeal: false
     syncOptions:
       - RespectIgnoreDifferences=true
+{% for opt in ocp4_workload_gitops_bootstrap_sync_options %}
+      - {{ opt }}
+{% endfor %}
   ignoreDifferences:
     - group: ""
       kind: ConfigMap


### PR DESCRIPTION
## Summary
- Adds `ocp4_workload_gitops_bootstrap_sync_options` list variable to the `ocp4_workload_gitops_bootstrap` role
- Allows catalog items to add custom `syncOptions` to the generated ArgoCD Application
- `RespectIgnoreDifferences=true` is always included (backwards compatible)
- Default is an empty list — no change for existing catalog items

## Motivation
When an ArgoCD Application includes both operator Subscriptions and CRs that depend on those operators' CRDs (e.g. RHTAS `Securesign` CR in the same app as the `rhtas-operator` Subscription), the dry-run fails because the CRD doesn't exist yet at dry-run time. `SkipDryRunOnMissingResource=true` is the standard ArgoCD solution, but the current template has no way to set it.

## Usage
```yaml
ocp4_workload_gitops_bootstrap_sync_options:
  - SkipDryRunOnMissingResource=true
```

## Test plan
- [ ] Verify existing catalog items without the new variable still deploy correctly (empty list default)
- [ ] Verify catalog items setting the variable get the additional syncOptions in the Application spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)