### PR TITLE
Make keycloak SSO route hostname prefix configurable

### DIFF
--- a/roles/ocp4_workload_authentication/defaults/main.yml
+++ b/roles/ocp4_workload_authentication/defaults/main.yml
@@ -95,6 +95,8 @@ ocp4_workload_authentication_htpasswd_secret_name: htpasswd
 # Keycloak Settings
 # --------------------------------
 
+ocp4_workload_authentication_keycloak_host_prefix: sso
+
 ocp4_workload_authentication_keycloak_namespace: keycloak
 
 ocp4_workload_authentication_keycloak_channel: stable-v26.2

--- a/roles/ocp4_workload_authentication/tasks/report_data_and_messages.yml
+++ b/roles/ocp4_workload_authentication/tasks/report_data_and_messages.yml
@@ -6,7 +6,7 @@
       is enabled on this cluster.
 
       {% if ocp4_workload_authentication_provider == 'keycloak' %}
-      Keycloak admin console: https://sso.{{ openshift_cluster_ingress_domain }}
+      Keycloak admin console: https://{{ ocp4_workload_authentication_keycloak_host_prefix }}.{{ openshift_cluster_ingress_domain }}
 
       Keycloak admin user: {{ _ocp4_workload_authentication_keycloak_admin_username }}
 
@@ -44,7 +44,7 @@
   when: ocp4_workload_authentication_provider == 'keycloak'
   agnosticd.core.agnosticd_user_info:
     data:
-      keycloak_admin_console: https://sso.{{ openshift_cluster_ingress_domain }}
+      keycloak_admin_console: https://{{ ocp4_workload_authentication_keycloak_host_prefix }}.{{ openshift_cluster_ingress_domain }}
       keycloak_admin_user: "{{ _ocp4_workload_authentication_keycloak_admin_username }}"
       keycloak_admin_password: "{{ _ocp4_workload_authentication_keycloak_admin_password }}"
 

--- a/roles/ocp4_workload_authentication/tasks/setup_keycloak.yml
+++ b/roles/ocp4_workload_authentication/tasks/setup_keycloak.yml
@@ -122,7 +122,7 @@
       --name {{ ocp4_workload_authentication_keycloak_default_realm }}
       --client-id {{ ocp4_workload_authentication_keycloak_openshift_client_id }}
       --client-secret {{ _ocp4_workload_authentication_keycloak_openshift_client_secret }}
-      --issuer-url https://sso.{{ openshift_cluster_ingress_domain }}/realms/{{ ocp4_workload_authentication_keycloak_default_realm }}
+      --issuer-url https://{{ ocp4_workload_authentication_keycloak_host_prefix }}.{{ openshift_cluster_ingress_domain }}/realms/{{ ocp4_workload_authentication_keycloak_default_realm }}
       --email-claims email
       --name-claims name
       --username-claims preferred_username

--- a/roles/ocp4_workload_authentication/templates/keycloak/instance.yml.j2
+++ b/roles/ocp4_workload_authentication/templates/keycloak/instance.yml.j2
@@ -17,7 +17,7 @@ spec:
       name: keycloak-pgsql-user
     vendor: postgres
   hostname:
-    hostname: sso.{{ openshift_cluster_ingress_domain }}
+    hostname: {{ ocp4_workload_authentication_keycloak_host_prefix }}.{{ openshift_cluster_ingress_domain }}
     strict: false
     strictBackchannel: false
   http:

--- a/roles/ocp4_workload_authentication/templates/keycloak/openshift-oauth.yml.j2
+++ b/roles/ocp4_workload_authentication/templates/keycloak/openshift-oauth.yml.j2
@@ -21,4 +21,4 @@ spec:
         name: openid-client-secret-bb6zw
       extraScopes: []
       issuer: >-
-        https://sso.{{ openshift_cluster_ingress_domain }}/realms/{{ ocp4_workload_authentication_keycloak_default_realm }}
+        https://{{ ocp4_workload_authentication_keycloak_host_prefix }}.{{ openshift_cluster_ingress_domain }}/realms/{{ ocp4_workload_authentication_keycloak_default_realm }}

--- a/roles/ocp4_workload_authentication/templates/keycloak/route.yml.j2
+++ b/roles/ocp4_workload_authentication/templates/keycloak/route.yml.j2
@@ -3,7 +3,7 @@ apiVersion: route.openshift.io/v1
 metadata:
   name: keycloak
 spec:
-  host: sso.{{ openshift_cluster_ingress_domain }}
+  host: {{ ocp4_workload_authentication_keycloak_host_prefix }}.{{ openshift_cluster_ingress_domain }}
   to:
     kind: Service
     name: keycloak

--- a/roles/ocp4_workload_authentication_keycloak/defaults/main.yml
+++ b/roles/ocp4_workload_authentication_keycloak/defaults/main.yml
@@ -3,6 +3,8 @@
 # Keycloak Operator
 # --------------------------------
 
+ocp4_workload_authentication_keycloak_host_prefix: sso
+
 ocp4_workload_authentication_keycloak_namespace: keycloak
 
 ocp4_workload_authentication_keycloak_pgsql_user: keycloak

--- a/roles/ocp4_workload_authentication_keycloak/tasks/workload.yml
+++ b/roles/ocp4_workload_authentication_keycloak/tasks/workload.yml
@@ -124,11 +124,11 @@
   agnosticd.core.agnosticd_user_info:
     msg: >-
       Authentication via Keycloak is enabled on this cluster.
-      Keycloak admin console: https://sso.{{ openshift_cluster_ingress_domain }}
+      Keycloak admin console: https://{{ ocp4_workload_authentication_keycloak_host_prefix }}.{{ openshift_cluster_ingress_domain }}
       Keycloak admin user: {{ r_keycloak_credentials.resources[0].data.username | b64decode }}
       Keycloak admin password: {{ r_keycloak_credentials.resources[0].data.password | b64decode }}
     data:
-      keycloak_admin_console: https://sso.{{ openshift_cluster_ingress_domain }}
+      keycloak_admin_console: https://{{ ocp4_workload_authentication_keycloak_host_prefix }}.{{ openshift_cluster_ingress_domain }}
       keycloak_admin_user: "{{ r_keycloak_credentials.resources[0].data.username | b64decode }}"
       keycloak_admin_password: "{{ r_keycloak_credentials.resources[0].data.password | b64decode }}"
       openshift_api_server_url: "{{ openshift_api_url }}"

--- a/roles/ocp4_workload_authentication_keycloak/templates/keycloak_instance.yml.j2
+++ b/roles/ocp4_workload_authentication_keycloak/templates/keycloak_instance.yml.j2
@@ -17,7 +17,7 @@ spec:
       name: keycloak-pgsql-user
     vendor: postgres
   hostname:
-    hostname: sso.{{ openshift_cluster_ingress_domain }}
+    hostname: {{ ocp4_workload_authentication_keycloak_host_prefix }}.{{ openshift_cluster_ingress_domain }}
     strict: false
     strictBackchannel: false
   http:

--- a/roles/ocp4_workload_authentication_keycloak/templates/keycloak_route.yml.j2
+++ b/roles/ocp4_workload_authentication_keycloak/templates/keycloak_route.yml.j2
@@ -3,7 +3,7 @@ apiVersion: route.openshift.io/v1
 metadata:
   name: keycloak
 spec:
-  host: sso.{{ openshift_cluster_ingress_domain }}
+  host: {{ ocp4_workload_authentication_keycloak_host_prefix }}.{{ openshift_cluster_ingress_domain }}
   to:
     kind: Service
     name: keycloak

--- a/roles/ocp4_workload_authentication_keycloak/templates/openshift-oauth.yml.j2
+++ b/roles/ocp4_workload_authentication_keycloak/templates/openshift-oauth.yml.j2
@@ -21,4 +21,4 @@ spec:
         name: openid-client-secret-bb6zw
       extraScopes: []
       issuer: >-
-        https://sso.{{ openshift_cluster_ingress_domain }}/realms/{{ ocp4_workload_authentication_keycloak_default_realm }}
+        https://{{ ocp4_workload_authentication_keycloak_host_prefix }}.{{ openshift_cluster_ingress_domain }}/realms/{{ ocp4_workload_authentication_keycloak_default_realm }}


### PR DESCRIPTION
Add ocp4_workload_authentication_keycloak_host_prefix variable (default: sso) to both ocp4_workload_authentication and ocp4_workload_authentication_keycloak roles, replacing the previously hardcoded "sso" prefix. Existing callers are unaffected.